### PR TITLE
Return save_tm as full bigint in microseconds at every object insert/…

### DIFF
--- a/src/lib/Libdb/db_postgres_job.c
+++ b/src/lib/Libdb/db_postgres_job.c
@@ -763,6 +763,8 @@ pg_db_del_attr_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pb
 {
 	char *raw_array = NULL;
 	int len = 0;
+	//static int ji_savetm_fnum;
+	//static int fnums_inited = 0;
 
 	if ((len = convert_db_attr_list_to_array(&raw_array, attr_list)) <= 0)
 		return -1;
@@ -770,11 +772,19 @@ pg_db_del_attr_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pb
 
 	SET_PARAM_BIN(conn, raw_array, len, 1);
 
-	if (pg_db_cmd(conn, STMT_REMOVE_JOBATTRS, 2) != 0)
+	if (pg_db_cmd_ret(conn, STMT_REMOVE_JOBATTRS, 2) !=0)
 		return -1;
 
-	free(raw_array);
+	/*
+	if (fnums_inited == 0) {
+		ji_savetm_fnum = PQfnumber(conn->conn_resultset, "ji_savetm");
+		fnums_inited = 1;
+	}
+	GET_PARAM_BIGINT(conn->conn_resultset, 0, pjob->ji_savetm, ji_savetm_fnum);
+	PQclear(conn->conn_resultset);
+	*/
 
+	free(raw_array);
 	return 0;
 }
 

--- a/src/lib/Libdb/db_postgres_job.c
+++ b/src/lib/Libdb/db_postgres_job.c
@@ -94,8 +94,9 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"values ($1, $2, $3, $4, $5, $6, $7, $8, $9, "
 		"$10, $11, $12, $13,"
 		"$14, $15, $16, $17, $18, $19, $20, $21, $22, $23,"
-		 "localtimestamp, localtimestamp,"
-		"hstore($24::text[]))");
+		"localtimestamp, localtimestamp,"
+		"hstore($24::text[])) "
+		"returning ji_savetm");
 
 	if (pg_prepare_stmt(conn, STMT_INSERT_JOB, conn->conn_sql, 24) != 0)
 		return -1;
@@ -125,14 +126,16 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"ji_qrank = $23,"
 		"ji_savetm = localtimestamp,"
 		"attributes = attributes || hstore($24::text[]) "
-		"where ji_jobid = $1");
+		"where ji_jobid = $1 "
+		"returning ji_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_JOB, conn->conn_sql, 24) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.job set "
 		"ji_savetm = localtimestamp,"
 		"attributes = attributes - hstore($2::text[]) "
-		"where ji_jobid = $1");
+		"where ji_jobid = $1 "
+		"returning ji_savetm");
 	if (pg_prepare_stmt(conn, STMT_REMOVE_JOBATTRS, conn->conn_sql, 2) != 0)
 		return -1;
 
@@ -160,7 +163,8 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"ji_credtype = $22,"
 		"ji_qrank = $23,"
 		"ji_savetm = localtimestamp "
-		"where ji_jobid = $1");
+		"where ji_jobid = $1 "
+		"returning ji_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_JOB_QUICK, conn->conn_sql, 23) != 0)
 		return -1;
 
@@ -188,8 +192,8 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"ji_4ash,"
 		"ji_credtype,"
 		"ji_qrank,"
-		"extract(epoch from ji_savetm)::bigint as ji_savetm, "
-		"extract(epoch from ji_creattm)::bigint as ji_creattm, "
+		"ji_savetm, "
+		"ji_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from pbs.job where ji_jobid = $1");
 	if (pg_prepare_stmt(conn, STMT_SELECT_JOB, conn->conn_sql, 1) != 0)
@@ -221,10 +225,10 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 			"ji_4ash,"
 			"ji_credtype,"
 			"ji_qrank,"
-			"extract(epoch from ji_savetm)::bigint as ji_savetm, "
-			"extract(epoch from ji_creattm)::bigint as ji_creattm, "
+			"ji_savetm, "
+			"ji_creattm, "
 			"hstore_to_array(attributes) as attributes "
-			"from pbs.job where extract(epoch from ji_savetm)::bigint > $1 "
+			"from pbs.job where ji_savetm > $1 "
 			"order by ji_qrank ");
 		if (pg_prepare_stmt(conn, STMT_FINDJOBS_FROM_TIME, conn->conn_sql, 1) != 0)
 			return -1;
@@ -284,8 +288,8 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"ji_4ash,"
 		"ji_credtype,"
 		"ji_qrank,"
-		"extract(epoch from ji_savetm)::bigint as ji_savetm, "
-		"extract(epoch from ji_creattm)::bigint as ji_creattm, "
+		"ji_savetm, "
+		"ji_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from pbs.job order by ji_qrank");
 	if (pg_prepare_stmt(conn, STMT_FINDJOBS_ORDBY_QRANK, conn->conn_sql, 0) != 0)
@@ -315,11 +319,11 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 		"ji_4ash,"
 		"ji_credtype,"
 		"ji_qrank,"
-		"extract(epoch from ji_savetm)::bigint as ji_savetm, "
-		"extract(epoch from ji_creattm)::bigint as ji_creattm, "
+		"ji_savetm, "
+		"ji_creattm, "
 		"hstore_to_array(attributes) as attributes "
-		"from pbs.job where ji_queue = $1"
-		" order by ji_qrank");
+		"from pbs.job where ji_queue = $1 "
+		"order by ji_qrank");
 	if (pg_prepare_stmt(conn, STMT_FINDJOBS_BYQUE_ORDBY_QRANK,
 		conn->conn_sql, 1) != 0)
 		return -1;
@@ -454,6 +458,8 @@ pg_db_save_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	int params;
 	int rc;
 	char *raw_array = NULL;
+	static int ji_savetm_fnum;
+	static int fnums_inited = 0;
 
 	SET_PARAM_STR(conn, pjob->ji_jobid, 0);
 	SET_PARAM_INTEGER(conn, pjob->ji_state, 1);
@@ -498,7 +504,15 @@ pg_db_save_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	else
 		stmt = STMT_INSERT_JOB;
 
-	rc = pg_db_cmd(conn, stmt, params);
+	rc = pg_db_cmd_ret(conn, stmt, params);
+	if (rc == 0) {
+		if (fnums_inited == 0) {
+			ji_savetm_fnum = PQfnumber(conn->conn_resultset, "ji_savetm");
+			fnums_inited = 1;
+		}
+		GET_PARAM_BIGINT(conn->conn_resultset, 0, pjob->ji_savetm, ji_savetm_fnum);
+		PQclear(conn->conn_resultset);
+	}
 
 	free(raw_array);
 

--- a/src/lib/Libdb/db_postgres_que.c
+++ b/src/lib/Libdb/db_postgres_que.c
@@ -364,6 +364,8 @@ pg_db_del_attr_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pb
 {
 	char *raw_array = NULL;
 	int len = 0;
+	//static int qu_mtime_fnum;
+	//static int fnums_inited = 0;
 
 	if ((len = convert_db_attr_list_to_array(&raw_array, attr_list)) <= 0)
 		return -1;
@@ -371,9 +373,18 @@ pg_db_del_attr_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pb
 
 	SET_PARAM_BIN(conn, raw_array, len, 1);
 
-	if (pg_db_cmd(conn, STMT_REMOVE_QUEATTRS, 2) != 0)
+	if (pg_db_cmd_ret(conn, STMT_REMOVE_QUEATTRS, 2) !=0)
 		return -1;
 
+	/*
+	if (fnums_inited == 0) {
+		qu_mtime_fnum = PQfnumber(conn->conn_resultset, "qu_mtime");
+		fnums_inited = 1;
+	}
+	GET_PARAM_BIGINT(conn->conn_resultset, 0, pq->qu_mtime, qu_mtime_fnum);
+
+	PQclear(conn->conn_resultset);
+	*/
 	free(raw_array);
 
 	return 0;

--- a/src/lib/Libdb/db_postgres_que.c
+++ b/src/lib/Libdb/db_postgres_que.c
@@ -71,7 +71,8 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 		"attributes "
 		") "
 		"values "
-		"($1, $2,  localtimestamp, localtimestamp, hstore($3::text[]))");
+		"($1, $2,  localtimestamp, localtimestamp, hstore($3::text[])) "
+		"returning qu_mtime");
 
 	if (pg_prepare_stmt(conn, STMT_INSERT_QUE, conn->conn_sql, 3) != 0)
 		return -1;
@@ -81,7 +82,8 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 			"qu_type = $2, "
 			"qu_mtime = localtimestamp, "
 			"attributes = hstore($3::text[])"
-			" where qu_name = $1");
+			" where qu_name = $1 "
+			"returning qu_mtime");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_QUE_FULL, conn->conn_sql, 3) != 0)
 		return -1;
 
@@ -89,14 +91,15 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.queue set "
 		"qu_mtime = localtimestamp,"
 		"attributes = attributes - hstore($2::text[]) "
-		"where qu_name = $1");
+		"where qu_name = $1 "
+		"returning qu_mtime");
 	if (pg_prepare_stmt(conn, STMT_REMOVE_QUEATTRS, conn->conn_sql, 2) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select qu_name, "
 			"qu_type, "
-			"extract(epoch from qu_ctime)::bigint as qu_ctime, "
-			"extract(epoch from qu_mtime)::bigint as qu_mtime, "
+			"qu_ctime, "
+			"qu_mtime, "
 			"hstore_to_array(attributes) as attributes "
 			"from pbs.queue "
 			"where qu_name = $1");
@@ -110,8 +113,8 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
 			"qu_name, "
 			"qu_type, "
-			"extract(epoch from qu_ctime)::bigint as qu_ctime, "
-			"extract(epoch from qu_mtime)::bigint as qu_mtime, "
+			"qu_ctime, "
+			"qu_mtime, "
 			"hstore_to_array(attributes) as attributes "
 			"from pbs.queue order by qu_ctime");
 	if (pg_prepare_stmt(conn, STMT_FIND_QUES_ORDBY_CREATTM, conn->conn_sql, 0) != 0)
@@ -191,6 +194,9 @@ pg_db_save_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	char *stmt;
 	int params;
 	char *raw_array = NULL;
+	int rc;
+	static int qu_mtime_fnum;
+	static int fnums_inited = 0;
 
 	SET_PARAM_STR(conn, pq->qu_name, 0);
 	SET_PARAM_INTEGER(conn, pq->qu_type, 1);
@@ -212,9 +218,14 @@ pg_db_save_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	else
 		stmt = STMT_INSERT_QUE;
 
-	if (pg_db_cmd(conn, stmt, params) != 0) {
-		free(raw_array);
-		return -1;
+	rc = pg_db_cmd_ret(conn, stmt, params);
+	if (rc == 0) {
+		if (fnums_inited == 0) {
+			qu_mtime_fnum = PQfnumber(conn->conn_resultset, "qu_mtime");
+			fnums_inited = 1;
+		}
+		GET_PARAM_BIGINT(conn->conn_resultset, 0, pq->qu_mtime, qu_mtime_fnum);
+		PQclear(conn->conn_resultset);
 	}
 
 	free(raw_array);

--- a/src/lib/Libdb/db_postgres_resv.c
+++ b/src/lib/Libdb/db_postgres_resv.c
@@ -132,8 +132,8 @@ pg_db_prepare_resv_sqls(pbs_db_conn_t *conn)
 		"ri_un_type, "
 		"ri_fromsock, "
 		"ri_fromaddr, "
-		"extract(epoch from ri_savetm)::bigint as ri_savetm, "
-		"extract(epoch from ri_creattm)::bigint as ri_creattm, "
+		"ri_savetm, "
+		"ri_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from pbs.resv where ri_resvid = $1");
 	if (pg_prepare_stmt(conn, STMT_SELECT_RESV, conn->conn_sql, 1) != 0)
@@ -159,8 +159,8 @@ pg_db_prepare_resv_sqls(pbs_db_conn_t *conn)
 		"ri_un_type, "
 		"ri_fromsock, "
 		"ri_fromaddr, "
-		"extract(epoch from ri_savetm)::bigint as ri_savetm, "
-		"extract(epoch from ri_creattm)::bigint as ri_creattm, "
+		"ri_savetm, "
+		"ri_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from pbs.resv "
 		"order by ri_creattm");

--- a/src/lib/Libdb/db_postgres_sched.c
+++ b/src/lib/Libdb/db_postgres_sched.c
@@ -367,6 +367,8 @@ pg_db_del_attr_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, 
 {
 	char *raw_array = NULL;
 	int len = 0;
+	//static int sched_savetm_fnum;
+	//static int fnums_inited = 0;
 
 	if ((len = convert_db_attr_list_to_array(&raw_array, attr_list)) <= 0)
 		return -1;
@@ -374,8 +376,17 @@ pg_db_del_attr_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, 
 
 	SET_PARAM_BIN(conn, raw_array, len, 1);
 
-	if (pg_db_cmd(conn, STMT_REMOVE_SCHEDATTRS, 2) != 0)
+	if (pg_db_cmd_ret(conn, STMT_REMOVE_SCHEDATTRS, 2) != 0)
 		return -1;
+
+	/*
+	if (fnums_inited == 0) {
+		sched_savetm_fnum = PQfnumber(conn->conn_resultset, "sched_savetm");
+		fnums_inited = 1;
+	}
+	GET_PARAM_BIGINT(conn->conn_resultset, 0, psch->sched_savetm, sched_savetm_fnum);
+	PQclear(conn->conn_resultset);
+	*/
 
 	free(raw_array);
 

--- a/src/lib/Libdb/db_postgres_sched.c
+++ b/src/lib/Libdb/db_postgres_sched.c
@@ -69,7 +69,8 @@ pg_db_prepare_sched_sqls(pbs_db_conn_t *conn)
 		"sched_creattm, "
 		"attributes "
 		") "
-		"values ($1, localtimestamp, localtimestamp, hstore($2::text[]))");
+		"values ($1, localtimestamp, localtimestamp, hstore($2::text[])) "
+		"returning sched_savetm");
 	if (pg_prepare_stmt(conn, STMT_INSERT_SCHED, conn->conn_sql, 2) != 0)
 		return -1;
 
@@ -77,21 +78,23 @@ pg_db_prepare_sched_sqls(pbs_db_conn_t *conn)
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.scheduler set "
 		"sched_savetm = localtimestamp, "
 		"attributes = hstore($2::text[]) "
-		"where sched_name = $1");
+		"where sched_name = $1 "
+		"returning sched_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_SCHED_FULL, conn->conn_sql, 2) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.scheduler set "
 		"sched_savetm = localtimestamp,"
 		"attributes = attributes - hstore($2::text[]) "
-		"where sched_name = $1");
+		"where sched_name = $1 "
+		"returning sched_savetm");
 	if (pg_prepare_stmt(conn, STMT_REMOVE_SCHEDATTRS, conn->conn_sql, 2) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
 		"sched_name, "
-		"extract(epoch from sched_savetm)::bigint as sched_savetm, "
-		"extract(epoch from sched_creattm)::bigint as sched_creattm, "
+		"sched_savetm, "
+		"sched_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from "
 		"pbs.scheduler "
@@ -104,32 +107,32 @@ pg_db_prepare_sched_sqls(pbs_db_conn_t *conn)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
-			"sched_name, "
-			"extract(epoch from sched_savetm)::bigint as sched_savetm, "
-			"extract(epoch from sched_creattm)::bigint as sched_creattm, "
-			"hstore_to_array(attributes) as attributes "
-			"from "
-			"pbs.scheduler "
-			"where attributes->'partition.' like $1");
+		"sched_name, "
+		"sched_savetm, "
+		"sched_creattm, "
+		"hstore_to_array(attributes) as attributes "
+		"from "
+		"pbs.scheduler "
+		"where attributes->'partition.' like $1");
 	if (pg_prepare_stmt(conn, STMT_SELECT_SCHED_PARTITION, conn->conn_sql, 1) != 0)
 		return -1;
 
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
-			"sched_name, "
-			"extract(epoch from sched_savetm)::bigint as sched_savetm, "
-			"extract(epoch from sched_creattm)::bigint as sched_creattm, "
-			"hstore_to_array(attributes) as attributes "
-			"from "
-			"pbs.scheduler "
-			"where not exist(attributes, 'partition.')");
+		"sched_name, "
+		"sched_savetm, "
+		"sched_creattm, "
+		"hstore_to_array(attributes) as attributes "
+		"from "
+		"pbs.scheduler "
+		"where not exist(attributes, 'partition.')");
 	if (pg_prepare_stmt(conn, STMT_SELECT_DFLT_SCHED, conn->conn_sql, 1) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
 		"sched_name, "
-		"extract(epoch from sched_savetm)::bigint as sched_savetm, "
-		"extract(epoch from sched_creattm)::bigint as sched_creattm, "
+		"sched_savetm, "
+		"sched_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from "
 		"pbs.scheduler ");
@@ -162,6 +165,9 @@ pg_db_save_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	char *stmt;
 	int params;
 	char *raw_array = NULL;
+	static int sched_savetm_fnum;
+	static int fnums_inited = 0;
+	int rc;
 
 	SET_PARAM_STR(conn, psch->sched_name, 0);
 
@@ -182,9 +188,14 @@ pg_db_save_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	else
 		stmt = STMT_INSERT_SCHED;
 
-	if (pg_db_cmd(conn, stmt, params) != 0) {
-		free(raw_array);
-		return -1;
+	rc = pg_db_cmd_ret(conn, stmt, params);
+	if (rc == 0) {
+		if (fnums_inited == 0) {
+			sched_savetm_fnum = PQfnumber(conn->conn_resultset, "sched_savetm");
+			fnums_inited = 1;
+		}
+		GET_PARAM_BIGINT(conn->conn_resultset, 0, psch->sched_savetm, sched_savetm_fnum);
+		PQclear(conn->conn_resultset);
 	}
 
 	free(raw_array);

--- a/src/lib/Libdb/db_postgres_svr.c
+++ b/src/lib/Libdb/db_postgres_svr.c
@@ -75,7 +75,8 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		"attributes "
 		") "
 		"values "
-		"($1, $2, $3, $4, $5, localtimestamp, localtimestamp, hstore($6::text[]))");
+		"($1, $2, $3, $4, $5, localtimestamp, localtimestamp, hstore($6::text[])) "
+		"returning sv_savetm");
 	if (pg_prepare_stmt(conn, STMT_INSERT_SVR, conn->conn_sql, 6) != 0)
 		return -1;
 
@@ -87,7 +88,8 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		"sv_svraddr = $4, "
 		"sv_svrport = $5, "
 		"sv_savetm = localtimestamp, "
-		"attributes = hstore($6::text[]) ");
+		"attributes = hstore($6::text[]) "
+		"returning sv_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_SVR_FULL, conn->conn_sql, 6) != 0)
 		return -1;
 
@@ -97,13 +99,15 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		"sv_jobidnumber = $3, "
 		"sv_svraddr = $4, "
 		"sv_svrport = $5, "
-		"sv_savetm = localtimestamp ");
+		"sv_savetm = localtimestamp "
+		"returning sv_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_SVR_QUICK, conn->conn_sql, 5) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.server set "
 		"sv_savetm = localtimestamp,"
-		"attributes = attributes - hstore($1::text[]) ");
+		"attributes = attributes - hstore($1::text[]) "
+		"returning sv_savetm");
 	if (pg_prepare_stmt(conn, STMT_REMOVE_SVRATTRS, conn->conn_sql, 1) != 0)
 		return -1;
 
@@ -111,8 +115,8 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		"sv_numjobs, "
 		"sv_numque, "
 		"sv_jobidnumber, "
-		"extract(epoch from sv_savetm)::bigint as sv_savetm, "
-		"extract(epoch from sv_creattm)::bigint as sv_creattm, "
+		"sv_savetm, "
+		"sv_creattm, "
 		"hstore_to_array(attributes) as attributes "
 		"from "
 		"pbs.server ");
@@ -120,7 +124,7 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		return -1;
 
 	strcat(conn->conn_sql, " FOR UPDATE");
-	if (pg_prepare_stmt(conn, STMT_SELECT_SVR_LOCKED, conn->conn_sql, 1) != 0)
+	if (pg_prepare_stmt(conn, STMT_SELECT_SVR_LOCKED, conn->conn_sql, 0) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
@@ -182,6 +186,9 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	int params;
 	int rc = 0;
 	char *raw_array = NULL;
+	static int sv_savetm_fnum;
+	static int fnums_inited = 0;
+	PGresult *res;
 
 	SET_PARAM_INTEGER(conn, ps->sv_numjobs, 0);
 	SET_PARAM_INTEGER(conn, ps->sv_numque, 1);
@@ -208,9 +215,15 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	else
 		stmt = STMT_INSERT_SVR;
 
-	if (pg_db_cmd(conn, stmt, params) != 0) {
-		free(raw_array);
-		rc = -1;
+	rc = pg_db_cmd_ret(conn, stmt, params);
+	if (rc == 0) {
+		res = conn->conn_resultset;
+		if (fnums_inited == 0) {
+			sv_savetm_fnum = PQfnumber(res, "sv_savetm");
+			fnums_inited = 1;
+		}
+		GET_PARAM_BIGINT(res, 0, ps->sv_savetm, sv_savetm_fnum);
+		PQclear(res);
 	}
 
 	free(raw_array);
@@ -270,7 +283,6 @@ pg_db_load_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock)
 	GET_PARAM_INTEGER(res, 0, ps->sv_numque, sv_numque_fnum);
 	GET_PARAM_BIGINT(res, 0, ps->sv_jobidnumber, sv_jobidnumber_fnum);
 	GET_PARAM_BIGINT(res, 0, ps->sv_creattm, sv_creattm_fnum);
-	GET_PARAM_BIGINT(res, 0, ps->sv_savetm, sv_savetm_fnum);
 	GET_PARAM_BIN(res, 0, raw_array, attributes_fnum);
 
 	/* convert attributes from postgres raw array format */

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -402,10 +402,6 @@ job_save_db(job *pjob, int updatetype)
 	else
 		savetype = PBS_UPDATE_DB_FULL;
 
-
-	sprintf(log_buffer, "Trying to save job %s, updatetype=%d, savetype=%d", pjob->ji_qs.ji_jobid, updatetype, savetype);
-	log_err(-1, __func__, log_buffer);
-
 	if (svr_to_db_job(pjob, &dbjob, savetype) != 0)
 		goto db_err;
 
@@ -455,6 +451,9 @@ job_save_db(job *pjob, int updatetype)
 
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
 		goto db_err;
+
+	pjob->ji_savetm = dbjob.ji_savetm; /* update savetm when we save a job, so that we do not save multiple times */
+
 	pbs_db_reset_obj(&obj);
 	pjob->ji_modified = 0;
 	pjob->ji_newjob = 0; /* reset dontsave - job is now saved */

--- a/src/server/queue_recov_db.c
+++ b/src/server/queue_recov_db.c
@@ -184,6 +184,8 @@ que_save_db(pbs_queue *pque, int mode)
 	    goto db_err;
 	}
 
+	pque->qu_qs.qu_mtime = dbque.qu_mtime;
+
 	pbs_db_reset_obj(&obj);
 
 	return (0);
@@ -234,6 +236,7 @@ que_recov_db(char *qname, pbs_queue *pq, int lock)
 		dbque.qu_mtime = pq->qu_qs.qu_mtime;
 	else
 		dbque.qu_mtime = 0;
+
 	strncpy(dbque.qu_name, qname, sizeof(dbque.qu_name));
 
 	if (!pq) {
@@ -246,7 +249,6 @@ que_recov_db(char *qname, pbs_queue *pq, int lock)
 	}
 
 	/* read in job fixed sub-structure */
-
 	rc = pbs_db_load_obj(conn, &obj, lock);
 	if (rc == -1){
 		goto db_err;

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -356,6 +356,7 @@ svr_save_db(struct server *ps, int mode)
 		savetype = PBS_INSERT_DB;
 		rc = pbs_db_save_obj(conn, &obj, savetype);
 	}
+	server.sv_qs.sv_savetm = dbsvr.sv_savetm;
 
 	pbs_db_reset_obj(&obj);
 
@@ -427,6 +428,8 @@ sched_save_db(pbs_sched *ps, int mode)
 		rc = pbs_db_save_obj(conn, &obj, savetype);
 	}
 
+	ps->sch_svtime = dbsched.sched_savetm;
+	
 	/* free the attribute list allocated by encode_attrs */
 	pbs_db_reset_obj(&obj);
 


### PR DESCRIPTION
Return savetm of every object (currently only job/que/svr/sched) on every save. 
Updated all time format to be full set of microseconds