### PR TITLE
Code changes to minimize sched_save_db calls

### DIFF
--- a/src/scheduler/pbsfs.c
+++ b/src/scheduler/pbsfs.c
@@ -173,6 +173,11 @@ main(int argc, char *argv[])
 		}
 
 		bs = pbs_statsched(pbs_sd, sched_name, NULL, NULL);
+		if (bs == NULL) {
+			fprintf(stderr, "Scheduler %s does not exist\n", sched_name);
+			exit(1);
+		}
+
 		for (cur_attrl = bs->attribs; cur_attrl != NULL; cur_attrl = cur_attrl->next) {
 			if (strcmp(cur_attrl->name, ATTR_sched_priv) == 0) {
 				strncpy(path_buf, cur_attrl->value, sizeof(path_buf));

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -885,6 +885,7 @@ req_stat_sched(struct batch_request *preq)
 	int rc = 0;
 	pbs_sched *psched;
 
+
 	/* allocate a reply structure and a status sub-structure */
 
 	preply = &preq->rq_reply;
@@ -895,13 +896,15 @@ req_stat_sched(struct batch_request *preq)
 	if(strlen(preq->rq_ind.rq_status.rq_id) != 0) {
 		psched = recov_sched_from_db(NULL,preq->rq_ind.rq_status.rq_id);
 
-		/* derive the scheduler state as this is transient and not going to save this in db */
-		if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
-			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
-					&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
-		else
-			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
-					&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+		if (strcmp(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN) != 0) {
+			/* derive the scheduler state as this is transient and not going to save this in db */
+			if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
+				set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+						&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
+			else
+				set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+						&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+		}
 
 		if(psched) {
 			if (strcmp(psched->sc_name, "default") == 0)
@@ -948,13 +951,15 @@ req_stat_sched(struct batch_request *preq)
 						psched->sch_attr[SCHED_ATR_throughput_mode].at_flags = 0;
 					}
 
-					/* derive the scheduler state as this is transient and not going to save this in db */
-					if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
-						set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
-								&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
-					else
-						set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
-								&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+					if (strcmp(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN) != 0) {
+						/* derive the scheduler state as this is transient and not going to save this in db */
+						if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
+							set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+									&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
+						else
+							set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+									&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+					}
 
 					stat_reply = status_sched(psched, preq, &preply->brp_un.brp_status);
 					if (stat_reply != 0)

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -87,6 +87,7 @@
 #include "pbs_license.h"
 #include "resource.h"
 #include "pbs_sched.h"
+#include "pbs_share.h"
 
 
 /* Global Data Items: */
@@ -893,7 +894,15 @@ req_stat_sched(struct batch_request *preq)
 	psched = NULL;
 	if(strlen(preq->rq_ind.rq_status.rq_id) != 0) {
 		psched = recov_sched_from_db(NULL,preq->rq_ind.rq_status.rq_id);
-		/*psched = find_scheduler(preq->rq_ind.rq_status.rq_id);*/
+
+		/* derive the scheduler state as this is transient and not going to save this in db */
+		if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
+			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+					&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
+		else
+			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+					&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+
 		if(psched) {
 			if (strcmp(psched->sc_name, "default") == 0)
 				dflt_scheduler = psched;
@@ -938,6 +947,15 @@ req_stat_sched(struct batch_request *preq)
 						/* check if throughput mode is visible in non-TPP mode, if so make it invisible */
 						psched->sch_attr[SCHED_ATR_throughput_mode].at_flags = 0;
 					}
+
+					/* derive the scheduler state as this is transient and not going to save this in db */
+					if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
+						set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+								&sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
+					else
+						set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+								&sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+
 					stat_reply = status_sched(psched, preq, &preply->brp_un.brp_status);
 					if (stat_reply != 0)
 						break;

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -368,6 +368,7 @@ schedule_high(pbs_sched *psched)
 	if (psched->scheduler_sock == -1) {
 		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
 			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
+			sched_save_db(psched, SVR_SAVE_FULL);
 			return (-1);
 		}
 		set_sched_sock(s, psched);
@@ -445,6 +446,7 @@ schedule_jobs(pbs_sched *psched)
 
 		if ((s = contact_sched(cmd, jid, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
 			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
+			sched_save_db(psched, SVR_SAVE_FULL);
 			return (-1);
 		}
 		else if (pdefr != NULL)
@@ -649,6 +651,7 @@ recov_sched_from_db(char *partition, char *sched_name)
 
 	dbsched.partition_name[0] = '\0';
 	dbsched.sched_name[0] = '\0';
+
 
 	if (partition != NULL) {
 		snprintf(dbsched.partition_name, sizeof(dbsched.partition_name), "%%%s%%", partition);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -368,7 +368,6 @@ schedule_high(pbs_sched *psched)
 	if (psched->scheduler_sock == -1) {
 		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
 			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
-			(void)sched_save_db(psched, SVR_SAVE_FULL);
 			return (-1);
 		}
 		set_sched_sock(s, psched);
@@ -381,7 +380,6 @@ schedule_high(pbs_sched *psched)
 	}
 
 	set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
-	(void)sched_save_db(psched, SVR_SAVE_FULL);
 
 	return 1;
 }
@@ -447,7 +445,6 @@ schedule_jobs(pbs_sched *psched)
 
 		if ((s = contact_sched(cmd, jid, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
 			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
-			(void)sched_save_db(psched, SVR_SAVE_FULL);
 			return (-1);
 		}
 		else if (pdefr != NULL)
@@ -460,7 +457,6 @@ schedule_jobs(pbs_sched *psched)
 		psched->svr_do_schedule = SCH_SCHEDULE_NULL;
 
 		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
-		(void)sched_save_db(psched, SVR_SAVE_FULL);
 
 		first_time = 0;
 
@@ -512,7 +508,6 @@ scheduler_close(int sock)
 		return;
 
 	set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
-	(void)sched_save_db(psched, SVR_SAVE_FULL);
 
 	if ((sock != -1) && (sock == psched->scheduler_sock2)) {
 		psched->scheduler_sock2 = -1;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -949,7 +949,7 @@ action_svr_iteration(attribute *pattr, void *pobj, int mode)
 {
 	/* set this attribute on main scheduler */
 	if (dflt_scheduler) {
-		if (mode == ATR_ACTION_NEW || mode == ATR_ACTION_ALTER || mode == ATR_ACTION_RECOV) {
+		if (mode == ATR_ACTION_NEW || mode == ATR_ACTION_ALTER || mode != ATR_ACTION_RECOV) {
 			dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_val.at_long = pattr->at_val.at_long;
 			dflt_scheduler->sch_attr[SCHED_ATR_schediteration].at_flags |=
 					ATR_VFLAG_SET | ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->


#### Describe Your Change
Reduce sched_save_db calls for sched object.
fix pbsfs crash when unknown scheduler is given as parameter to the argument -I.

Solution:

1. Reduced lot of sched_save_db calls by not storing scheduler's state in to DB.
2. Scheduler now has only two states i.e. idle if scheduling is false for that scheduler or scheduling if scheduling for that scheduler is true or 1.
3. Making use of the flag  ATR_ACTION_RECOV to make sure we do not call uncessary sched_save_db calls. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
SmokeTest got passed. Also made sure that pbsfs does not crash in case of unknown scheduler.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
