### PR TITLE
Fixed missing array jobs state and substate during refresh_job and added >= to the db query

### DIFF
--- a/src/lib/Libdb/db_postgres_job.c
+++ b/src/lib/Libdb/db_postgres_job.c
@@ -228,7 +228,7 @@ pg_db_prepare_job_sqls(pbs_db_conn_t *conn)
 			"ji_savetm, "
 			"ji_creattm, "
 			"hstore_to_array(attributes) as attributes "
-			"from pbs.job where ji_savetm > $1 "
+			"from pbs.job where ji_savetm >= $1 "
 			"order by ji_qrank ");
 		if (pg_prepare_stmt(conn, STMT_FINDJOBS_FROM_TIME, conn->conn_sql, 1) != 0)
 			return -1;

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -710,11 +710,13 @@ setup_arrayjob_attrs(attribute *pattr, void *pobj, int mode)
 
 	if ((mode == ATR_ACTION_NEW) || (mode == ATR_ACTION_RECOV)) {
 		int pbs_error = PBSE_BADATVAL;
-		if (pjob->ji_ajtrk)
-			free(pjob->ji_ajtrk);
-		if ((pjob->ji_ajtrk = mk_subjob_index_tbl(pjob->ji_wattr[(int)JOB_ATR_array_indices_submitted].at_val.at_str,
-			                                      JOB_STATE_QUEUED, &pbs_error)) == NULL)
-			return pbs_error;
+		/* it's just a hack to try not to free the pjob->ji_ajtrk structure when caller is refresh_job */
+		if (pjob->ji_ajtrk == NULL) {
+			//free(pjob->ji_ajtrk);
+			if ((pjob->ji_ajtrk = mk_subjob_index_tbl(pjob->ji_wattr[(int)JOB_ATR_array_indices_submitted].at_val.at_str,
+													  JOB_STATE_QUEUED, &pbs_error)) == NULL)
+				return pbs_error;
+		}
 	}
 
 	if (mode == ATR_ACTION_RECOV) {

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -559,6 +559,12 @@ refresh_job(char *jobid) {
 			job_attr_def[i].at_free(&stale_job_ptr->ji_wattr[i]);
 		}
 
+		/* db_to_svr_job makes call to decode_attr_db which further calls setup_arrjob_attrs through action function
+		* and there we are freeing the structure stale_job_ptr->ji_ajtrk
+		* resulting parent looses his control on it's subjobs
+		* Added a hack in setup_arrjob_attrs to fix the problem for time being only
+		*/
+
 		/* refresh all the job attributes */
 		if (db_to_svr_job(stale_job_ptr, &dbjob) != 0) {
 			snprintf(log_buffer, LOG_BUF_SIZE, "Failed to refresh job attribute %s", dbjob.ji_jobid);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -696,8 +696,13 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 			return (job_save(pjob, SAVEJOB_NEW));
 		else
 			return (job_save(pjob, SAVEJOB_FULL));
-	} else if (changed)
-		return (job_save(pjob, SAVEJOB_QUICK));
+	} else if (changed) {
+		/* this call saves the parent array job state and it's substate */
+		if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob)
+		   return (job_save(pjob, SAVEJOB_FULL));
+		else
+		   return (job_save(pjob, SAVEJOB_QUICK));
+	}
 
 	return (0);
 }


### PR DESCRIPTION

#### Describe Bug or Feature
1. Parrent array job state was not coming as expected because PBS doesn't save the parent attributes to the db.
2. db_to_svr_job call freeing the subjob tracking table index from parent job structure during refresh_job() call.

#### Describe Your Change
1. Saving the parent job attributes to the db through svr_setjobstate().
2. Added a check to the setup_arrayjob_attrs 
