### PR TITLE
Implemented stateless reservations and fixed array job preemption issue

### DIFF
--- a/src/include/reservation.h
+++ b/src/include/reservation.h
@@ -232,6 +232,8 @@ struct resc_resv {
 	struct work_task	*resv_start_task;
 	struct work_task	*resv_end_task;
 
+	time_t	ri_savetm;
+
 	/*
 	 * fixed size internal data - maintained via "quick save"
 	 * some of the items are copies of attributes, if so this
@@ -317,8 +319,9 @@ struct resc_resv {
 #define	Q_CHNG_ENABLE		0
 #define	Q_CHNG_START		1
 
-extern resc_resv  *find_resv(char *);
+extern resc_resv  *find_resv(char *, int);
 extern resc_resv  *resc_resv_alloc(void);
+extern resc_resv  *resv_recov_db(char *, resc_resv *, int);
 extern void  resv_purge(resc_resv *);
 extern int   start_end_dur_wall(void *, int);
 

--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -3684,7 +3684,7 @@ _pps_helper_get_resv(resc_resv *presv_o, const char *resvid)
 			log_err(PBSE_INTERNAL, __func__, log_buffer);
 			return NULL;
 		}
-		presv = find_resv((char *)resvid_out);
+		presv = find_resv((char *)resvid_out, 0);
 	}
 
 	if (presv == NULL) {

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -776,6 +776,10 @@ fixup_arrayindicies(attribute *pattr, void *pobj, int mode)
 	job  *pjob = pobj;
 	char *str;
 
+	/* it's a hack only is just to bypass this function during refresh_job() */
+	if(mode == ATR_ACTION_RECOV)
+		return (PBSE_NONE);
+
 	/* set all all sub jobs expired,  then reset queued the ones in "remaining" */
 	for (i=0; i < pjob->ji_ajtrk->tkm_ct; i++)
 		set_subjob_tblstate(pjob, i, JOB_STATE_EXPIRED);

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -126,6 +126,8 @@ extern time_t time_now;
 #ifndef PBS_MOM
 
 extern job *refresh_job(char *);
+extern resc_resv *refresh_resv(char *);
+extern pbs_list_head	svr_allresvs;
 
 /**
  * @brief
@@ -335,6 +337,7 @@ db_to_svr_resv(resc_resv *presv, pbs_db_resv_info_t *pdresv)
 	presv->ri_qs.ri_svrflags = pdresv->ri_svrflags;
 	presv->ri_qs.ri_tactive = pdresv->ri_tactive;
 	presv->ri_qs.ri_type = pdresv->ri_type;
+	presv->ri_savetm = pdresv->ri_savetm;
 
 	if ((decode_attr_db(presv, &pdresv->attr_list, resv_attr_def,
 		presv->ri_wattr,
@@ -527,6 +530,8 @@ refresh_job(char *jobid) {
 	pbs_db_conn_t *conn = svr_db_conn;
 	pbs_db_obj_info_t obj;
 	pbs_db_job_info_t dbjob;
+	char comment_buffer[LOG_BUF_SIZE] = {'\0'}; /* for backing up the comment */
+	int cmnt_flag = 0;
 
 	/* get the old pointer of the job, if job is in AVL tree */
 	stale_job_ptr = find_job_avl(jobid);
@@ -554,15 +559,20 @@ refresh_job(char *jobid) {
 			return NULL;
 		}
 
+		/* job comment backup */
+		if(stale_job_ptr->ji_wattr[JOB_ATR_Comment].at_val.at_str != NULL) {
+			sprintf(comment_buffer, "%s", stale_job_ptr->ji_wattr[JOB_ATR_Comment].at_val.at_str);
+			cmnt_flag = 1;
+		}
 		/* remove any malloc working job attribute space */
 		for (i=0; i < (int)JOB_ATR_LAST; i++) {
 			job_attr_def[i].at_free(&stale_job_ptr->ji_wattr[i]);
 		}
 
-		/* db_to_svr_job makes call to decode_attr_db which further calls setup_arrjob_attrs through action function
+		/* db_to_svr_job makes call to decode_attr_db which further calls setup_arrayjob_attrs through action function
 		* and there we are freeing the structure stale_job_ptr->ji_ajtrk
 		* resulting parent looses his control on it's subjobs
-		* Added a hack in setup_arrjob_attrs to fix the problem for time being only
+		* Added a hack in setup_arrayjob_attrs to fix the problem for time being only
 		*/
 
 		/* refresh all the job attributes */
@@ -572,8 +582,86 @@ refresh_job(char *jobid) {
 			pbs_db_reset_obj(&obj);
 			return NULL;
 		}
+		/* assigned job comment again to the job */
+		if(cmnt_flag)
+			job_attr_def[(int)JOB_ATR_Comment].at_decode(&stale_job_ptr->ji_wattr[(int)JOB_ATR_Comment],
+					NULL, NULL, comment_buffer);
 		pbs_db_reset_obj(&obj);
 		return stale_job_ptr;
+	}
+}
+
+/**
+ * @brief
+ *	Refresh/retrieve reservation from database and add it into AVL tree if not present
+ *
+ * @param[in]	resvid - Reservation id to refresh
+ *
+ * @return	The recovered reservation
+ * @retval	NULL - Failure
+ * @retval	!NULL - Success, pointer to resv structure recovered
+ *
+ */
+resc_resv *
+refresh_resv(char *resvid) {
+	int i;
+	resc_resv *new_resv_ptr = NULL;
+	resc_resv *stale_resv_ptr = NULL;
+	pbs_db_conn_t *conn = svr_db_conn;
+	pbs_db_obj_info_t obj;
+	pbs_db_resv_info_t dbresv;
+
+	/* get the old pointer of the resv, if resv is in svr list */
+	char *at;
+	if ((at = strchr(resvid, (int)'@')) != 0)
+		*at = '\0';	/* strip of @server_name */
+	stale_resv_ptr = (resc_resv *)GET_NEXT(svr_allresvs);
+	while (stale_resv_ptr != NULL) {
+		if (!strcmp(resvid, stale_resv_ptr->ri_qs.ri_resvID))
+			break;
+		stale_resv_ptr = (resc_resv *)GET_NEXT(stale_resv_ptr->ri_allresvs);
+	}
+
+	if (at)
+		*at = '@';	/* restore @server_name */
+
+	if(stale_resv_ptr == NULL) {
+		/* if resv is not in list, load the resv from database */
+		new_resv_ptr = resv_recov_db(resvid, stale_resv_ptr, 0);
+		if (new_resv_ptr == NULL) {
+			snprintf(log_buffer, LOG_BUF_SIZE, "Failed to recover reservation from db %s", resvid);
+			log_err(-1, "refresh_resv", log_buffer);
+			return NULL;
+		}
+		/* add resv to server list */
+		append_link(&svr_allresvs, &new_resv_ptr->ri_allresvs, new_resv_ptr);
+		return new_resv_ptr;
+	} else {
+		strcpy(dbresv.ri_resvid, resvid);
+		obj.pbs_db_obj_type = PBS_DB_RESV;
+		obj.pbs_db_un.pbs_db_resv = &dbresv;
+
+		if (pbs_db_load_obj(conn, &obj, 0) != 0) {
+			snprintf(log_buffer, LOG_BUF_SIZE, "Failed to load resv %s", dbresv.ri_resvid);
+			log_err(-1, "refresh_resv", log_buffer);
+			pbs_db_reset_obj(&obj);
+			return NULL;
+		}
+
+		/* remove any malloc working resv attribute space */
+		for (i=0; i < (int)RESV_ATR_LAST; i++) {
+			resv_attr_def[i].at_free(&stale_resv_ptr->ri_wattr[i]);
+		}
+
+		/* refresh all the resv attributes */
+		if (db_to_svr_resv(stale_resv_ptr, &dbresv) != 0) {
+			snprintf(log_buffer, LOG_BUF_SIZE, "Failed to refresh resv attribute %s", dbresv.ri_resvid);
+			log_err(-1, "refresh_resv", log_buffer);
+			pbs_db_reset_obj(&obj);
+			return NULL;
+		}
+		pbs_db_reset_obj(&obj);
+		return stale_resv_ptr;
 	}
 }
 
@@ -733,36 +821,53 @@ db_err:
  *
  */
 resc_resv *
-resv_recov_db(char *resvid)
+resv_recov_db(char *resvid, resc_resv  *presv, int lock)
 {
-	resc_resv               *presv;
+	//resc_resv               *presv;
 	pbs_db_resv_info_t	dbresv;
 	pbs_db_obj_info_t       obj;
 	pbs_db_conn_t *conn = svr_db_conn;
-
-	presv = resc_resv_alloc();
-	if (presv == NULL) {
-		return NULL;
-	}
-
-	if (pbs_db_begin_trx(conn, 0, 0) !=0)
-		goto db_err;
+	int rc = 0;
+	int i;
+	int oldresv = 1;
 
 	strcpy(dbresv.ri_resvid, resvid);
 	obj.pbs_db_obj_type = PBS_DB_RESV;
 	obj.pbs_db_un.pbs_db_resv = &dbresv;
 
-	/* read in job fixed sub-structure */
-	if (pbs_db_load_obj(conn, &obj, 0) != 0)
+	if (presv)
+		dbresv.ri_savetm = presv->ri_savetm;
+	else
+		dbresv.ri_savetm = 0;
+
+	if (!presv) {
+		presv = resc_resv_alloc();
+		oldresv = 0;
+		if (presv == NULL) {
+			log_err(-1, "resv_recov", "resc_resv_alloc failed");
+			return NULL;
+		}
+	}
+
+	/* read in resv fixed sub-structure */
+	rc = pbs_db_load_obj(conn, &obj, lock);
+	if (rc == -1)
 		goto db_err;
+
+	if (rc == -2)
+		return presv;
+
+	if (oldresv) {
+		/* remove any malloc working attribute space */
+		for (i = 0; i < (int)RESV_ATR_LAST; i++) {
+			resv_attr_def[i].at_free(&presv->ri_wattr[i]);
+		}
+	}
 
 	if (db_to_svr_resv(presv, &dbresv) != 0)
 		goto db_err;
 
 	pbs_db_reset_obj(&obj);
-
-	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
-		goto db_err;
 
 	return (presv);
 db_err:
@@ -772,7 +877,6 @@ db_err:
 	sprintf(log_buffer, "Failed to recover resv %s", resvid);
 	log_err(-1, "resv_recov", log_buffer);
 
-	(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
 	return NULL;
 }
 
@@ -850,7 +954,7 @@ void*
 job_or_resv_recov_db(char *id, int objtype)
 {
 	if (objtype == RESC_RESV_OBJECT) {
-		return (resv_recov_db(id));
+		return (resv_recov_db(id, NULL, 0));
 	} else {
 		return (job_recov_db(id, NULL, 0));
 	}

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1604,8 +1604,12 @@ vnode_available(struct pbsnode *np)
 					/* Otherwise revert its state to Confirmed */
 					resv_setResvState(presv, RESV_CONFIRMED, RESV_CONFIRMED);
 				}
+				
 				/* Unset all of the reservation retry attributes and values */
 				unset_resv_retry(presv);
+				/* This resv_save is called to save any state changes done is resv_setResvState function */
+				if (presv->ri_modified)
+					(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 			}
 		} else {
 			/* An inconsistency in recognizing node state transitions caused an
@@ -1770,6 +1774,10 @@ vnode_unavailable(struct pbsnode *np, int account_vnode)
 			}
 		} else if (degraded_time > resv_start_time)
 			(void) resv_setResvState(presv, presv->ri_qs.ri_state, RESV_DEGRADED);
+
+		/* This resv_save is called to save any state changes done is resv_setResvState function */
+		if (presv->ri_modified)
+			(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 
 		/* reference count the number of vnodes down such that the state of the
 		 * reservation can be reset to CONFIRMED once the number of unavailable
@@ -8424,6 +8432,9 @@ set_old_subUniverse(resc_resv	*presv)
 
 		/* unset the reservation retry time attribute */
 		unset_resv_retry(presv);
+		/* This resv_save is called to save any state changes done is resv_setResvState function */
+		if (presv->ri_modified)
+			(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 	}
 	free(sp);
 }

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -231,6 +231,7 @@ int   Rmv_if_resv_not_possible(job *);
 static int   attach_queue_to_reservation(resc_resv *);
 static void  call_log_license(struct work_task *);
 extern int create_resreleased(job *pjob);
+int am_i_resv_owner(char *);
 
 extern pbs_sched *sched_alloc(char *sched_name, int append);
 
@@ -907,30 +908,35 @@ pbsd_init(int type)
 		return (-1);
 	}
 	while ((rc = pbs_db_cursor_next(conn, state, &obj)) == 0) {
-		/* recover reservation */
-		presv = (resc_resv *) job_or_resv_recov(dbresv.ri_resvid,
-			RESC_RESV_OBJECT);
-		if (presv != NULL) {
+		/* As part of multi server, will check the reservation owner(server)
+		 * and then only load the reservation from db and add it to the list for quick availabilty.
+		 */
+		if(am_i_resv_owner(dbresv.ri_resvid)) {
+			/* recover reservation */
+			presv = (resc_resv *) job_or_resv_recov(dbresv.ri_resvid,
+				RESC_RESV_OBJECT);
+			if (presv != NULL) {
 
-			is_resv_window_in_future(presv);
-			set_old_subUniverse(presv);
+				is_resv_window_in_future(presv);
+				set_old_subUniverse(presv);
 
-			append_link(&svr_allresvs, &presv->ri_allresvs, presv);
-			if (attach_queue_to_reservation(presv)) {
+				append_link(&svr_allresvs, &presv->ri_allresvs, presv);
+				if (attach_queue_to_reservation(presv)) {
 
-				/* reservation needed queue; failed to find it */
-				sprintf(log_buffer, msg_init_resvNOq,
-					presv->ri_qs.ri_queue, presv->ri_qs.ri_resvID);
-				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN |
-					PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV,
-					LOG_NOTICE, msg_daemonname, log_buffer);
-			} else {
+					/* reservation needed queue; failed to find it */
+					sprintf(log_buffer, msg_init_resvNOq,
+						presv->ri_qs.ri_queue, presv->ri_qs.ri_resvID);
+					log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN |
+						PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV,
+						LOG_NOTICE, msg_daemonname, log_buffer);
+				} else {
 
-				sprintf(log_buffer, msg_init_recovresv,
-					presv->ri_qs.ri_resvID);
-				log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN |
-					PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
-					LOG_INFO, msg_daemonname, log_buffer);
+					sprintf(log_buffer, msg_init_recovresv,
+						presv->ri_qs.ri_resvID);
+					log_event(PBSEVENT_SYSTEM | PBSEVENT_ADMIN |
+						PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
+						LOG_INFO, msg_daemonname, log_buffer);
+				}
 			}
 		}
 		pbs_db_reset_obj(&obj);
@@ -2049,7 +2055,7 @@ Rmv_if_resv_not_possible(job *pjob)
 		 *resc_resv structure exists and, if so, rejoin
 		 */
 
-		presv = find_resv(pjob->ji_qs.ji_jobid);
+		presv = find_resv(pjob->ji_qs.ji_jobid, 0);
 		if (presv == NULL ||
 			pjob->ji_wattr[JOB_ATR_reserve_end]
 			.at_val.at_long < time_now)
@@ -2157,3 +2163,7 @@ call_log_license(struct work_task *ptask)
 	(void)set_task(WORK_Timed, ntime, call_log_license, 0);
 }
 
+/* check the ownership of the reservtaion (i.e. servername)*/
+int am_i_resv_owner(char *resvid) {
+	return 1;
+}

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -1085,6 +1085,9 @@ req_deleteReservation(struct batch_request *preq)
 		eval_resvState(presv, RESVSTATE_req_deleteReservation,
 			relVal, &state, &sub);
 		(void) resv_setResvState(presv, state, sub);
+		/* This resv_save is called to save any state changes done is resv_setResvState function */
+		if (presv->ri_modified)
+			(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 		pjob = (job *) GET_NEXT(presv->ri_qp->qu_jobs);
 		while (pjob != NULL) {
 
@@ -1194,6 +1197,9 @@ req_deleteReservation(struct batch_request *preq)
 		eval_resvState(presv, RESVSTATE_req_deleteReservation,
 			relVal, &state, &sub);
 		(void) resv_setResvState(presv, state, sub);
+		/* This resv_save is called to save any state changes done is resv_setResvState function */
+		if (presv->ri_modified)
+			(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 		reply_ack(preq);
 		resv_purge(presv);
 		return;

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3909,7 +3909,7 @@ check_resource_set_on_jobs_or_resvs(struct batch_request *preq, resource_def *pr
 		}
 	}
 
-	/* Reject if resource is on a job and the type or flag are being modified */
+	/* Reject if resource is on a resource and the type or flag are being modified */
 	pr = (resc_resv *)GET_NEXT(svr_allresvs);
 	while (pr != NULL) {
 		pattr = &pr->ri_wattr[RESV_ATR_resource];

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -197,8 +197,8 @@ static	int	validate_place_req_of_job_in_reservation(job *pj);
 
 /* To generate the job/resv id's locally */
 long long svr_jobidnumber = -1; /* this should be loaded by init */
-
 static char *pbs_o_que = "PBS_O_QUEUE=";
+resc_resv *get_resv_for_que(char *);
 /**
  * @brief
  * 		validate_perm_res_in_select -	checks to see if the resources
@@ -1025,6 +1025,20 @@ req_quejob(struct batch_request *preq)
 	 *
 	 * Also check for conflict for job and reservation place spec
 	 */
+
+	/* As part of multi server need to fetch the reservation from the db if it's a reservation queue.
+	 * So for the time being let's assume it that if queue name starts with 'R' this means it's a resv queue.
+	 * For future: restrict the queue name starts with 'R' or else need to add an attr to queue structure for
+	 * finding out whether it's a queue or resv queue.
+	 */
+
+	int is_normal_que;
+	char resv_char[]="R";
+	is_normal_que = strncmp(pj->ji_qs.ji_queue, resv_char, 1);
+	if(!is_normal_que) {
+		/* it's a resv queue */
+		pque->qu_resvp = (resc_resv *)get_resv_for_que(pj->ji_qs.ji_queue);
+	}
 	if (pque->qu_resvp) {
 		job_attr_def[(int)JOB_ATR_reserve_ID].at_free(
 			&pj->ji_wattr[(int)JOB_ATR_reserve_ID]);
@@ -1253,6 +1267,27 @@ req_quejob(struct batch_request *preq)
 #endif	/* not PBS_MOM */
 }
 
+/* fetch reservation from the db related to the reservation queue */
+#ifndef PBS_MOM
+resc_resv *
+get_resv_for_que(char *que_name) {
+
+	/* find_resv() need full qualify name
+	 * i.e. R41.server_name so we need to make that name
+	 */
+	char	full_qu_name[300]; /* queue name */
+	resc_resv *qu_resvp;
+	snprintf(full_qu_name, sizeof(full_qu_name), "%s.%s", que_name, server_name);
+	qu_resvp = find_resv(full_qu_name, 0);
+	if(qu_resvp == NULL) {
+		sprintf(log_buffer,"Failed to fetch the reservation %s from database",
+				full_qu_name);
+			log_err(-1,__func__,log_buffer);
+			return NULL;
+	}
+	return qu_resvp;
+}
+#endif
 /**
  * @brief
  * 		req_jobcredential - receive a set of credentials to be used by the job
@@ -2171,7 +2206,7 @@ req_resvSub(struct batch_request *preq)
 	 * this capability, but will have this code here
 	 */
 
-	if ((presv = find_resv(rid)) == NULL) {
+	if ((presv = find_resv(rid, 0)) == NULL) {
 		/* Not on "all_resvs" list try "new_resvs" list */
 		presv = (resc_resv *)GET_NEXT(svr_newresvs);
 		while (presv) {
@@ -2598,8 +2633,7 @@ req_resvSub(struct batch_request *preq)
 	presv->ri_qs.ri_un.ri_newt.ri_fromsock = sock;
 	presv->ri_qs.ri_un.ri_newt.ri_fromaddr = get_connectaddr(sock);
 
-	/* start a transaction and save resv and server structure */
-	pbs_db_begin_trx(conn, 0, 0);
+	/* save resv and server structure */
 
 	if (job_or_resv_save((void *)presv, SAVERESV_NEW, RESC_RESV_OBJECT)) {
 		(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
@@ -2611,11 +2645,8 @@ req_resvSub(struct batch_request *preq)
 	/* Now, no need to save server here because server
 	   has already saved in the get_next_svr_sequence_id() */
 
-	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0) {
-		(void)resv_purge(presv);
-		req_reject(PBSE_SYSTEM, 0, preq);
-		return;
-	}
+	/* Removing begin and end transaction as we are not saving
+	   anything in server here. */
 
 	svr_jobidnumber = next_svr_sequence_id;
 

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -534,7 +534,13 @@ chk_rescResv_request(char *resvID, struct batch_request *preq)
 {
 	resc_resv	*presv;
 
-	if ((presv = find_resv(resvID)) == NULL) {
+	/* No need to lock the row when we are going to delete the reservation. Currently
+	   chk_rescResv_request is called for modify and delete reservation only. */
+	int lock = 0;
+	if(preq->rq_type == PBS_BATCH_ModifyResv)
+		lock = 1;
+
+	if ((presv = find_resv(resvID, lock)) == NULL) {
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_RESV, LOG_INFO,
 			resvID, msg_unkresvID);
 		req_reject(PBSE_UNKRESVID, 0, preq);

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -697,11 +697,10 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 		if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob)
 		   return (job_save(pjob, SAVEJOB_FULL));
 		else
-		   return (job_save(pjob, SAVEJOB_QUICK));
-		   */
-		  return (job_save(pjob, SAVEJOB_FULL));
-	}
-
+		   return (job_save(pjob, SAVEJOB_FULL));
+		*/
+		return (job_save(pjob, SAVEJOB_FULL));
+	}	
 	return (0);
 }
 
@@ -2883,6 +2882,9 @@ Time4resv(struct work_task *ptask)
 		resv_setResvState(presv, state, sub);
 		cmp_resvStateRelated_attrs((void *)presv,
 			presv->ri_qs.ri_type);
+		/* This resv_save is called to save any state changes done is resv_setResvState function */
+		if (presv->ri_modified)
+			(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 		if (presv->ri_qs.ri_type == RESV_JOB_OBJECT &&
 			(pjob = presv->ri_jbp)) {
 
@@ -3034,6 +3036,10 @@ Time4resvFinish(struct work_task *ptask)
 			 */
 			change_enableORstart(presv, Q_CHNG_START, "FALSE");
 			(void)resv_setResvState(presv, RESV_DELETING_JOBS, RESV_DELETING_JOBS);
+
+			/* This resv_save is called to save any state changes done is resv_setResvState function */
+			if (presv->ri_modified)
+				(void)job_or_resv_save((void *)presv, SAVERESV_FULL, RESC_RESV_OBJECT);
 
 			/* 2) Issue delete messages to jobs in running state and keep jobs in
 			 * Queued state. Server periodically monitors the reservation queue

--- a/src/tools/pbs_python.c
+++ b/src/tools/pbs_python.c
@@ -187,7 +187,7 @@ find_job(char *jobid)
 }
 
 resc_resv *
-find_resv(char *resvid)
+find_resv(char *resvid, int lock)
 {
 	return NULL;
 }

--- a/test/tests/pbs_smoketest.py
+++ b/test/tests/pbs_smoketest.py
@@ -63,7 +63,6 @@ class SmokeTest(PBSTestSuite):
         jid = self.server.submit(j)
         self.server.expect(JOB, {'job_state': 'R'}, id=jid)
 
-    '''
     @skipOnCpuSet
     def test_submit_job_array(self):
         """
@@ -113,7 +112,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(RESV, a, id=rid, interval=1)
         self.server.expect(JOB, {'job_state': 'R'}, jid1)
         self.server.expect(JOB, {'job_state': 'B'}, jid2)
-    '''
 
     def test_standing_reservation(self):
         """
@@ -188,7 +186,6 @@ class SmokeTest(PBSTestSuite):
         jobs = self.server.select()
         self.assertNotEqual(jobs, None)
 
-    '''
     def test_alter(self):
         """
         Test to alter job
@@ -200,7 +197,6 @@ class SmokeTest(PBSTestSuite):
         self.server.expect(JOB, {'job_state': 'Q'}, id=jid)
         self.server.alterjob(jid, {'comment': 'job comment altered'})
         self.server.expect(JOB, {'comment': 'job comment altered'}, id=jid)
-    '''
 
     def test_sigjob(self):
         """
@@ -294,7 +290,6 @@ class SmokeTest(PBSTestSuite):
         self.server.manager(MGR_CMD_CREATE, QUEUE, a, qname, expect=True)
         self.server.manager(MGR_CMD_DELETE, QUEUE, id=qname)
 
-    '''
     @skipOnCpuSet
     def test_fgc_limits(self):
         """
@@ -315,7 +310,6 @@ class SmokeTest(PBSTestSuite):
         j3id = self.server.submit(j3)
         self.server.expect(JOB, 'comment', op=SET, id=j3id)
         self.server.expect(JOB, {'job_state': 'Q'}, id=j3id)
-    '''
 
     @skipOnCpuSet
     def test_limits(self):
@@ -1129,7 +1123,6 @@ class SmokeTest(PBSTestSuite):
                                    {'session_id': (NOT, self.isSuspended)},
                                    id=job['id'])
 
-    '''
     @skipOnCpuSet
     def test_suspend_job_array_with_preempt(self):
         """
@@ -1153,7 +1146,6 @@ class SmokeTest(PBSTestSuite):
                 self.server.expect(JOB,
                                    {'session_id': (NOT, self.isSuspended)},
                                    id=job['id'])
-    '''
 
     def create_resource_helper(self, r, t, f, c):
         """
@@ -1338,7 +1330,6 @@ class SmokeTest(PBSTestSuite):
                 if d and len(d) > 0:
                     self.assertFalse(ar in d[0])
 
-    '''
     @timeout(720)
     def test_resource_delete(self):
         """
@@ -1367,7 +1358,6 @@ class SmokeTest(PBSTestSuite):
                         self.delete_resource_helper(
                             self.resc_name, t, f, c, k, v)
                         self.logger.info("")
-    '''
 
     def setup_fs(self, formula):
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->
#### Describe Your Change:
1. Make reservation object stateless.
2. Fetch reservation queue from database.
3. Reservation refreshes with the latest records from db during pbs_rstat same as qstat.
3. No need to fetch reservation and it's associated queue from db if the caller server itself is the owner of the reservation.
4. Fixed array job preemption issue.

Smoke test results has been attached for our reference only in which all tests are passed.
[ptl_smoketest_logs.txt](https://github.com/subhasisb/pbspro/files/3477675/ptl_smoketest_logs.txt)
