### PR TITLE
Making server object stateless and miscellenious changes 

### DIFF
--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -118,7 +118,7 @@ extern pbs_sched *sched_alloc(char *sched_name, int append);
 extern void sched_free(pbs_sched *psched);
 extern int db_to_svr_sched(struct pbs_sched *ps, pbs_db_sched_info_t *pdbsched);
 extern int sched_delete(pbs_sched *psched);
-extern pbs_sched * find_sched(char *sched_name);
+extern pbs_sched * find_sched(char *sched_name, int lock);
 extern pbs_net_t pbs_scheduler_addr;
 extern unsigned int pbs_scheduler_port;
 

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -113,7 +113,7 @@ extern void set_scheduler_flag(int flag, pbs_sched *psched);
 extern int find_assoc_sched_jid(char *jid, pbs_sched **target_sched);
 extern int find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched);
 extern pbs_sched *find_sched_from_sock(int sock);
-extern pbs_sched *recov_sched_from_db(char *partition,  char *sched_name);
+extern pbs_sched *recov_sched_from_db(char *partition,  char *sched_name, int lock);
 extern pbs_sched *sched_alloc(char *sched_name, int append);
 extern void sched_free(pbs_sched *psched);
 extern int db_to_svr_sched(struct pbs_sched *ps, pbs_db_sched_info_t *pdbsched);

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -118,7 +118,7 @@ extern pbs_sched *sched_alloc(char *sched_name, int append);
 extern void sched_free(pbs_sched *psched);
 extern int db_to_svr_sched(struct pbs_sched *ps, pbs_db_sched_info_t *pdbsched);
 extern int sched_delete(pbs_sched *psched);
-extern pbs_sched * find_sched(char *sched_name, int lock);
+extern pbs_sched *find_sched(char *sched_name, int lock);
 extern pbs_net_t pbs_scheduler_addr;
 extern unsigned int pbs_scheduler_port;
 

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -232,7 +232,6 @@ extern	long	reserve_retry_cutoff;
 #define SVR_HOSTACL "svr_hostacl"
 #define PBS_DEFAULT_NODE "1"
 
-#define SVR_SAVE_QUICK 0
 #define SVR_SAVE_FULL  1
 #define SVR_SAVE_NEW   2
 

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -197,6 +197,7 @@ struct server {
 	int	  sv_cur_prov_records; /* number of provisiong requests
 					 currently running */
 	struct memcache_state trx_status;
+	int loaded;
 };
 
 

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -710,6 +710,7 @@ pbsd_init(int type)
 			svr_attr_def[(int)SRV_ATR_Comment].at_free(
 				&server.sv_attr[(int)SRV_ATR_Comment]);
 		}
+		svr_save_db(&server, SVR_SAVE_FULL);
 
 	} else {	/* init type is "create" */
 		if (rc == 0) {		/* server was loaded */
@@ -732,6 +733,8 @@ pbsd_init(int type)
 
 		svr_save_db(&server, SVR_SAVE_NEW);
 	}
+
+
 
 	/* 4. Check License information */
 

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -641,7 +641,7 @@ pbsd_init(int type)
 	/* 5. If not a "create" initialization, recover server db */
 	/*    and sched db					  */
 	if (type != RECOV_CREATE) {
-		dflt_scheduler = recov_sched_from_db(NULL, "default");
+		dflt_scheduler = recov_sched_from_db(NULL, "default", 1);
 		if (!dflt_scheduler) {
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
 			set_sched_default(dflt_scheduler, 0);

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -647,8 +647,8 @@ pbsd_init(int type)
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
 			set_sched_default(dflt_scheduler, 0);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
-			pbs_db_end_trx(conn, PBS_DB_COMMIT);
 		}
+		pbs_db_end_trx(conn, PBS_DB_COMMIT);
 		dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
 		dflt_scheduler->pbs_scheduler_port = pbs_scheduler_port;
 	}

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -641,11 +641,13 @@ pbsd_init(int type)
 	/* 5. If not a "create" initialization, recover server db */
 	/*    and sched db					  */
 	if (type != RECOV_CREATE) {
+		pbs_db_begin_trx(conn, 0, 0);
 		dflt_scheduler = recov_sched_from_db(NULL, "default", 1);
 		if (!dflt_scheduler) {
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
 			set_sched_default(dflt_scheduler, 0);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
+			pbs_db_end_trx(conn, PBS_DB_COMMIT);
 		}
 		dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
 		dflt_scheduler->pbs_scheduler_port = pbs_scheduler_port;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2360,7 +2360,7 @@ next_task()
 		time_t delay;
 		if ((delay = psched->sch_next_schedule - time_now) <= 0) {
 			pbs_sched *new_sched;
-			new_sched = recov_sched_from_db(NULL, psched->sc_name);
+			new_sched = recov_sched_from_db(NULL, psched->sc_name, 0);
 			if (new_sched == NULL) {
 				/* if scheduler is not present in the database means one possibility is
 				 * somebody deleted it from another server so if this is the case then we need to

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1538,7 +1538,7 @@ mgr_server_set(struct batch_request *preq)
 	}
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 
-	svr_recov_db(0);
+	svr_recov_db(1);
 	rc = mgr_set_attr(server.sv_attr, svr_attr_def, SRV_ATR_LAST, plist,
 		preq->rq_perm, &bad_attr, (void *)&server,
 		ATR_ACTION_ALTER);
@@ -1571,7 +1571,7 @@ mgr_server_unset(struct batch_request *preq)
 	svrattrl *plist;
 	int	  rc;
 
-	svr_recov_db(0);
+	svr_recov_db(1);
 
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3440,11 +3440,7 @@ mgr_sched_delete(struct batch_request *preq)
 		}
 	}
 	reply_ack(preq); /*request completely successful*/
-	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0) {
-		req_reject(PBSE_SYSTEM, 0, preq);
-		return;
-	}
-	return;
+	pbs_db_end_trx(conn, PBS_DB_COMMIT);
 }
 
 /*

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1317,7 +1317,7 @@ struct batch_request *preq;
 		pque = NULL;
 	} else {
 		(void)que_save_db(pque, QUE_SAVE_NEW);
-		(void)svr_save_db(&server, SVR_SAVE_QUICK);
+		(void)svr_save_db(&server, SVR_SAVE_FULL);
 		(void)sprintf(log_buffer, msg_manager, msg_man_cre,
 			preq->rq_user, preq->rq_host);
 		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_QUEUE, LOG_INFO,
@@ -1433,7 +1433,7 @@ mgr_queue_delete(struct batch_request *preq)
 				rc = PBSE_OBJBUSY;
 			}
 			else {
-				svr_save_db(&server, SVR_SAVE_QUICK);
+				svr_save_db(&server, SVR_SAVE_FULL);
 				(void)sprintf(log_buffer, msg_manager, msg_man_del,
 					preq->rq_user, preq->rq_host);
 

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1538,6 +1538,7 @@ mgr_server_set(struct batch_request *preq)
 	}
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 
+	svr_recov_db(0);
 	rc = mgr_set_attr(server.sv_attr, svr_attr_def, SRV_ATR_LAST, plist,
 		preq->rq_perm, &bad_attr, (void *)&server,
 		ATR_ACTION_ALTER);
@@ -1569,6 +1570,8 @@ mgr_server_unset(struct batch_request *preq)
 	int	  bad_attr = 0;
 	svrattrl *plist;
 	int	  rc;
+
+	svr_recov_db(0);
 
 	plist = (svrattrl *)GET_NEXT(preq->rq_ind.rq_manager.rq_attr);
 

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -189,7 +189,7 @@ svr_shutdown(int type)
 
 	if (type == SHUT_QUICK) /* quick, leave jobs as are */
 		return;
-	svr_save_db(&server, SVR_SAVE_FULL);
+	//svr_save_db(&server, SVR_SAVE_FULL);
 
 	pnxt = (job *)GET_NEXT(svr_alljobs);
 	while ((pjob = pnxt) != NULL) {

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -189,7 +189,7 @@ svr_shutdown(int type)
 
 	if (type == SHUT_QUICK) /* quick, leave jobs as are */
 		return;
-	svr_save_db(&server, SVR_SAVE_QUICK);
+	svr_save_db(&server, SVR_SAVE_FULL);
 
 	pnxt = (job *)GET_NEXT(svr_alljobs);
 	while ((pjob = pnxt) != NULL) {

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -895,7 +895,7 @@ req_stat_sched(struct batch_request *preq)
 
 	psched = NULL;
 	if(strlen(preq->rq_ind.rq_status.rq_id) != 0) {
-		psched = recov_sched_from_db(NULL,preq->rq_ind.rq_status.rq_id);
+		psched = recov_sched_from_db(NULL,preq->rq_ind.rq_status.rq_id, 0);
 
 		if (strcmp(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN) != 0) {
 			/* derive the scheduler state as this is transient and not going to save this in db */
@@ -947,7 +947,7 @@ req_stat_sched(struct batch_request *preq)
 		count = pbs_db_get_rowcount(state);
 		if (count > 0) {
 			 while ((rc = pbs_db_cursor_next(conn, state, &obj)) == 0) {
-				psched = recov_sched_from_db(NULL, dbsched.sched_name);
+				psched = recov_sched_from_db(NULL, dbsched.sched_name, 0);
 				if(psched) {
 					if (strcmp(psched->sc_name, "default") == 0)
 						dflt_scheduler = psched;

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -782,6 +782,7 @@ req_stat_svr(struct batch_request *preq)
 	struct brp_status  *pstat;
 
 
+	svr_recov_db(0);
 	/* update count and state counts from sv_numjobs and sv_jobstates */
 
 	server.sv_attr[(int)SRV_ATR_TotalJobs].at_val.at_long = server.sv_numjobs;

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -218,7 +218,7 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 		*target_sched = find_scheduler_by_partition(pq->qu_attr[QA_ATR_partition].at_val.at_str);
 
 		if (*target_sched == NULL) {
-			*target_sched = recov_sched_from_db(pq->qu_attr[QA_ATR_partition].at_val.at_str, NULL);
+			*target_sched = recov_sched_from_db(pq->qu_attr[QA_ATR_partition].at_val.at_str, NULL, 0);
 			if (*target_sched == NULL) {
 				return 0;
 			} else
@@ -228,7 +228,7 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 	} else {
 		dflt_scheduler = *target_sched = find_scheduler("default");
 		if (!dflt_scheduler) {
-			dflt_scheduler = *target_sched = recov_sched_from_db(NULL, "default");
+			dflt_scheduler = *target_sched = recov_sched_from_db(NULL, "default", 0);
 			if (!dflt_scheduler) {
 				dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
 				set_sched_default(dflt_scheduler, 0);
@@ -633,7 +633,7 @@ set_scheduler_flag(int flag, pbs_sched *psched)
 }
 
 pbs_sched *
-recov_sched_from_db(char *partition, char *sched_name)
+recov_sched_from_db(char *partition, char *sched_name, int lock)
 {
 	int ret;
 	int append = 1;
@@ -672,7 +672,7 @@ recov_sched_from_db(char *partition, char *sched_name)
 	}
 
 	/* recover sched */
-	ret = pbs_db_load_obj(conn, &obj, 0);
+	ret = pbs_db_load_obj(conn, &obj, lock);
 
 	if ((ret == -2) || (ret != 0)) {
 		goto db_err;

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -400,7 +400,7 @@ poke_scheduler(attribute *pattr, void *pobj, int actmode)
 			}
 		} else {
 			svr_attr_def[(int) SRV_ATR_scheduling].at_set(&server.sv_attr[SRV_ATR_scheduling], pattr, SET);
-			svr_save_db(&server, SVR_SAVE_QUICK);
+			svr_save_db(&server, SVR_SAVE_FULL);
 		}
 		if (actmode == ATR_ACTION_ALTER) {
 			if (pattr->at_val.at_long)

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -119,7 +119,7 @@ find_sched(char *sched_name)
 	if (!sched_name)
 		return NULL;
 
-	psched = recov_sched_from_db(NULL, sched_name);
+	psched = recov_sched_from_db(NULL, sched_name, 1);
 	if (psched) {
 		if (strcmp(psched->sc_name, "default") == 0)
 			dflt_scheduler = psched;

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -113,13 +113,13 @@ sched_alloc(char *sched_name, int append)
  */
 
 pbs_sched *
-find_sched(char *sched_name)
+find_sched(char *sched_name, int lock)
 {
 	pbs_sched *psched = NULL;
 	if (!sched_name)
 		return NULL;
 
-	psched = recov_sched_from_db(NULL, sched_name, 1);
+	psched = recov_sched_from_db(NULL, sched_name, lock);
 	if (psched) {
 		if (strcmp(psched->sc_name, "default") == 0)
 			dflt_scheduler = psched;

--- a/src/server/svr_recov.c
+++ b/src/server/svr_recov.c
@@ -224,36 +224,8 @@ svr_save_fs(struct server *ps, int mode)
 	pmode = 0600;
 #endif
 
-	if (mode == SVR_SAVE_QUICK) {
-		sdb = open(path_svrdb, O_WRONLY | O_CREAT | O_Sync, pmode);
-		if (sdb < 0) {
-			log_err(errno, "svr_recov", msg_svdbopen);
-			return (-1);
-		}
-#ifdef WIN32
-		secure_file(path_svrdb, "Administrators",
-			READS_MASK|WRITES_MASK|STANDARD_RIGHTS_REQUIRED);
-		setmode(sdb, O_BINARY);
-#endif
-		while ((i=write(sdb, &ps->sv_qs, sizeof(struct server_qs))) !=
-			sizeof(struct server_qs)) {
-			if ((i == -1) && (errno == EINTR))
-				continue;
-			log_err(errno, __func__, msg_svdbnosv);
-			return (-1);
-		}
-#ifdef WIN32
-		if (_commit(sdb) != 0) {
-			log_err(errno, __func__, "flush server db file to disk failed!");
-			close(sdb);
-			return (-1);
-		}
-#endif
-
-		(void)close(sdb);
-
-	} else {	/* SVR_SAVE_FULL Save */
-
+	if (mode == SVR_SAVE_FULL) {
+		/* SVR_SAVE_FULL Save */
 		sdb = open(path_svrdb_new, O_WRONLY | O_CREAT | O_Sync, pmode);
 		if (sdb < 0) {
 			log_err(errno, "svr_recov", msg_svdbopen);
@@ -652,9 +624,6 @@ sched_save_fs(struct pbs_sched *ps, int mode)
 #else
 	pmode = 0600;
 #endif
-
-	if (mode == SVR_SAVE_QUICK)
-		return (-1);	/* invalid mode currently for scheduler */
 
 	/* Since only attributes, we only do a SVR_SAVE_FULL Save */
 

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -333,8 +333,6 @@ svr_save_db(struct server *ps, int mode)
 
 	if (mode == SVR_SAVE_FULL)
 		savetype = PBS_UPDATE_DB_FULL;
-	else if (mode == SVR_SAVE_QUICK)
-		savetype = PBS_UPDATE_DB_QUICK;
 	else
 		savetype = PBS_INSERT_DB;
 
@@ -403,8 +401,6 @@ sched_save_db(pbs_sched *ps, int mode)
 
 	if (mode == SVR_SAVE_FULL)
 		savetype = PBS_UPDATE_DB_FULL;
-	else if (mode == SVR_SAVE_QUICK)
-		savetype = PBS_UPDATE_DB_QUICK;
 	else
 		savetype = PBS_INSERT_DB;
 

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -243,7 +243,6 @@ svr_recov_db(int lock)
 	int		 i;
 	attribute	*pattr;
 	attribute_def	*pdef;
-	static int firsttime = 1;
 
 	/* load server_qs */
 	dbsvr.attr_list.attr_count = 0;
@@ -252,9 +251,8 @@ svr_recov_db(int lock)
 	obj.pbs_db_obj_type = PBS_DB_SVR;
 	obj.pbs_db_un.pbs_db_svr = &dbsvr;
 
-	if (firsttime) {
+	if (!server.loaded) {
 		dbsvr.sv_savetm = 0;
-		firsttime = 0;
 	} else {
 		dbsvr.sv_savetm = server.sv_qs.sv_savetm;
 		if (memcache_good(&server.trx_status, lock))
@@ -281,12 +279,14 @@ svr_recov_db(int lock)
 		pdef->at_free(pattr);
 	}
 
+
 	if (db_to_svr_svr(&server, &dbsvr) != 0)
 		goto db_err;
 
 	pbs_db_reset_obj(&obj);
 	memcache_update_state(&server.trx_status, lock);
 
+	server.loaded = 1;
 	return (0);
 
 db_err:


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Making server object stateless.


#### Describe Your Change

- Making server object stateless
- Code changes to avoid duplicate rows in server table
- Adding locking during setting/unsetting server attributes
- Atomicity during server set/unsetting of attributes
- Lock sched object wherever needed(Mostly during set/unset of its attributes)

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Ran smoke test. All tests are passing.



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
