### PR TITLE
Object recovery policy for sched object and miscellenious bug fixes

### DIFF
--- a/src/include/attribute.h
+++ b/src/include/attribute.h
@@ -596,6 +596,7 @@ extern int is_attr(int, char *, int);
 /* object cache status functionality */
 struct memcache_state {
 	long 			last_loaded_srv_trx;
+	long			last_loaded_sched_trx;
 	char			locked;
 };
 
@@ -603,6 +604,7 @@ extern int  memcache_good(struct memcache_state *ts, int lock);
 extern void memcache_update_state(struct memcache_state *ts, int lock);
 extern void memcache_reset_state(struct memcache_state *ts);
 extern void memcache_roll_srv_trx();
+extern void memcache_roll_sched_trx();
 
 /* "type" to pass to acl_check() */
 #define ACL_Host  1

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -64,6 +64,9 @@ extern "C" {
 
 #define SC_STATUS_LEN 	10
 
+#define SCHED_TRX_CHK 1
+#define SCHED_TRX_NOCHK 0
+
 /*attributes for the server's sched object*/
 enum sched_atr {
 	SCHED_ATR_SchedHost,
@@ -102,6 +105,7 @@ typedef struct pbs_sched {
 	time_t sch_next_schedule;		/* when to next run scheduler cycle */
 	char sc_name[PBS_MAXSCHEDNAME + 1];
 	char sch_svtime[DB_TIMESTAMP_LEN + 1];
+	struct memcache_state trx_status;
 	/* sched object's attributes  */
 	attribute sch_attr[SCHED_ATR_LAST];
 } pbs_sched;

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -277,6 +277,7 @@ extern void			set_sched_default(pbs_sched *, int unset_flag);
 extern pbs_sched *		find_scheduler(char *sched_name);
 extern pbs_sched *		find_scheduler_by_partition(char *partition);
 void				copy_sched_misc_not_in_db(pbs_sched *target, pbs_sched *src);
+int				is_conn_from_sched(int conn);
 extern void			set_attr_svr(attribute *pattr, attribute_def *pdef, char *value);
 extern int			license_sanity_check(void);
 extern void			memory_debug_log(struct work_task *ptask);

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2355,8 +2355,9 @@ next_task()
 	/* should the scheduler be run?  If so, adjust the delay time  */
 
 	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
-		time_t delay;
-		if ((delay = psched->sch_next_schedule - time_now) <= 0) {
+		time_t delay = 0;
+		if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
+				(delay = psched->sch_next_schedule - time_now) <= 0) {
 			pbs_sched *new_sched;
 			new_sched = recov_sched_from_db(NULL, psched->sc_name, 0);
 			if (new_sched == NULL) {

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -910,7 +910,7 @@ req_stat_sched(struct batch_request *preq)
 	if(strlen(preq->rq_ind.rq_status.rq_id) != 0) {
 		psched = recov_sched_from_db(NULL,preq->rq_ind.rq_status.rq_id, 0);
 
-		if (strcmp(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN) != 0) {
+		if (psched && strcmp(psched->sch_attr[(int) SCHED_ATR_sched_state].at_val.at_str, SC_DOWN) != 0) {
 			/* derive the scheduler state as this is transient and not going to save this in db */
 			if (psched->sch_attr[(int) SCHED_ATR_scheduling].at_val.at_long == 0)
 				set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -592,3 +592,15 @@ copy_sched_misc_not_in_db(pbs_sched *target, pbs_sched *src)
 	}
 }
 
+int
+is_conn_from_sched(int conn)
+{
+	pbs_sched *psched;
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		if (psched->scheduler_sock == conn)
+			return 1;
+	}
+	return 0;
+}
+
+


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Extend the framework of object recovery policy from db to Scheduler object as well. 


#### Describe Your Change
- Extend the framework of object recovery policy from db to Scheduler object as well. 
- Make sure that if there is any change in scheduler attributes, all other servers which cached this object also get updated as soon as possible
- In next_task we will check if it is time to call scheduler ONLY if at all if scheduling for the corresponding scheduler is true.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
- Smoke Test
- Made sure that change of scheduler attributes will reflect as soon as possible at the other servers
- Made sure that whenever a scheduler transaction happens we only recover sched object from db. Verified it through gdb.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
