### PR TITLE
Added code to refresh/retrieve the queue from db during qstat -Qf

### DIFF
--- a/src/lib/Libdb/db_postgres.h
+++ b/src/lib/Libdb/db_postgres.h
@@ -140,6 +140,7 @@ typedef unsigned __int64 uint64_t;
 #define STMT_DELETE_QUE "delete_que"
 #define STMT_FIND_QUES_ORDBY_CREATTM "find_ques_ordby_creattm"
 #define STMT_REMOVE_QUEATTRS "remove_queattrs"
+#define STMT_SELECT_QUE_FROM_TIME "select_que_from_time"
 
 /* node statement names */
 #define STMT_INSERT_NODE "insert_node"

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -104,6 +104,7 @@
 
 #ifndef PBS_MOM
 extern pbs_db_conn_t	*svr_db_conn;
+extern pbs_list_head svr_queues;
 #endif
 
 #ifdef NAS /* localmod 005 */
@@ -515,7 +516,8 @@ db_err:
  * @brief
  *	Refresh/retrieve job from database and add it into AVL tree if not present
  *
- * @param[in]	jobid - Job id of job to refresh
+ *	@param[in]	dbjob - The pointer to the wrapper job object of type pbs_db_job_info_t
+ *  @param[in]  refreshed - To count the no. of jobs refreshed
  *
  * @return	The recovered job
  * @retval	NULL - Failure
@@ -576,6 +578,56 @@ err:
 	log_err(-1, __func__, log_buffer);
 	return NULL;
 }
+
+/**
+ * @brief
+ *	Refresh/retrieve queue from database and add it into AVL tree if not present
+ *
+ *	@param[in]	dbque - The pointer to the wrapper queue object of type pbs_db_que_info_t
+ *  @param[in]  refreshed - To count the no. of queues refreshed
+ *
+ * @return	The recovered queue
+ * @retval	NULL - Failure
+ * @retval	!NULL - Success, pointer to queue structure recovered
+ *
+ */
+pbs_queue *
+refresh_queue(pbs_db_que_info_t *dbque, int *refreshed) {
+
+	*refreshed = 0;
+	char  *pc;
+	pbs_queue *pque = NULL;
+	char   qname[PBS_MAXDEST + 1];
+
+	(void)strncpy(qname, dbque->qu_name, PBS_MAXDEST);
+	qname[PBS_MAXDEST] ='\0';
+	pc = strchr(qname, (int)'@');	/* strip off server (fragment) */
+	if (pc)
+		*pc = '\0';
+	/* get the old pointer of the queue, if queue is already in memory */
+	pque = (pbs_queue *)GET_NEXT(svr_queues);
+	while (pque != NULL) {
+		if (strcmp(qname, pque->qu_qs.qu_name) == 0)
+			break;
+		pque = (pbs_queue *)GET_NEXT(pque->qu_link);
+	}
+	if (pc)
+		*pc = '@';	/* restore '@' server portion */
+
+	if (pque) {
+		if (strcmp(dbque->qu_savetm, pque->qu_savetm) != 0) {
+			/* if queue had changed in db */
+			*refreshed = 1;
+			return que_recov_db(dbque->qu_name, pque, 0);
+		}
+	} else {
+		/* if queue is not in memory, fetch it from db */
+		*refreshed = 1;
+		return que_recov_db(dbque->qu_name, pque, 0);
+	}
+	return pque;
+}
+
 
 /**
  * @brief


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
qstat -Qf command doesn't fetch newly added/modified queues from db


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Now, qstat -Qf will fetch queues from db if it's not in memory or else refresh the existing queue pointer with latest data.

