### PR TITLE
Fix for next_task getting called in a loop

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2355,9 +2355,9 @@ next_task()
 	/* should the scheduler be run?  If so, adjust the delay time  */
 
 	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
-		time_t delay = 0;
-		if (psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long &&
-				(delay = psched->sch_next_schedule - time_now) <= 0) {
+		time_t delay;
+		if (((delay = psched->sch_next_schedule - time_now) <= 0) &&
+				psched->sch_attr[SCHED_ATR_scheduling].at_val.at_long) {
 			pbs_sched *new_sched;
 			new_sched = recov_sched_from_db(NULL, psched->sc_name, 0);
 			if (new_sched == NULL) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
next_task is getting called continuously due to not calculating delay when scheduling is off.


#### Describe Your Change
calculate delay first and then check if scheduling is off/on and then proceed accordingly.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
Verified by making scheduling off and observed that next_task is not getting called continuously.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->