### PR TITLE
Queue synchronization and deletion between multiple servers

### DIFF
--- a/src/cmds/scripts/pbs_db_schema.sql
+++ b/src/cmds/scripts/pbs_db_schema.sql
@@ -115,8 +115,9 @@ CREATE INDEX nd_savetm_idx ON pbs.node(nd_savetm);
  * Table pbs.queue holds queue information
  */
 CREATE TABLE pbs.queue (
-    qu_name		    TEXT		NOT NULL,
-    qu_type		    INTEGER		NOT NULL,
+    qu_name		TEXT		NOT NULL,
+    qu_type		INTEGER		NOT NULL,
+    qu_deleted		INTEGER		NOT NULL,
     qu_creattm		TIMESTAMP	NOT NULL,
     qu_savetm		TIMESTAMP	NOT NULL,
     attributes		hstore		NOT NULL default '',

--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -82,8 +82,10 @@ extern "C" {
 #define PBS_UPDATE_DB_FULL 0
 #define PBS_UPDATE_DB_QUICK 1
 #define PBS_INSERT_DB 2
+#define PBS_UPDATE_DB_AS_DELETED 3 /* mark in db as deleted but it's still in db */
 
 #define DB_TIMESTAMP_LEN 50
+#define UNIQUE_KEY_VIOLATION 23505 /* postgres throws this error code in case of primary key violation */
 
 /**
  * @brief
@@ -253,6 +255,7 @@ typedef struct pbs_db_sched_info pbs_db_sched_info_t;
 struct pbs_db_que_info {
 	char    qu_name[PBS_MAXQUEUENAME +1];
 	INTEGER qu_type;
+	INTEGER qu_deleted;
 	char    qu_creattm[DB_TIMESTAMP_LEN + 1];
 	char    qu_savetm[DB_TIMESTAMP_LEN + 1];
 	pbs_db_attr_list_t attr_list; /* list of attributes */

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -61,6 +61,10 @@ extern "C" {
 #define QTYPE_RoutePush 2
 #define QTYPE_RoutePull 3
 
+/* for multi-server, given macros defines availability of queue */
+#define Q_Exist 0
+#define Q_Deleted 1
+
 /*
  * Attributes, including the various resource-lists are maintained in an
  * array in a "decoded or parsed" form for quick access to the value.
@@ -151,11 +155,13 @@ struct pbs_queue {
 	struct queuefix {
 		int	qu_modified;		/* != 0 => update disk file */
 		int	qu_type;		/* queue type: exec, route */
+		int	qu_deleted;		/* is queue exist or deleted, for multi-server */
 		char	qu_name[PBS_MAXQUEUENAME + 1]; /* queue name */
 	} qu_qs;
 
 	char		qu_creattm[DB_TIMESTAMP_LEN + 1];		/* time queue created */
 	char		qu_savetm[DB_TIMESTAMP_LEN + 1];		/* time queue last modified */
+	time_t		qu_last_refresh_time;				/* queue last refresh time */
 
 	int	qu_numjobs;			/* current numb jobs in queue */
 	int	qu_njstate[PBS_NUMJOBSTATE];	/* # of jobs per state */

--- a/src/lib/Libdb/db_postgres.h
+++ b/src/lib/Libdb/db_postgres.h
@@ -141,6 +141,7 @@ typedef unsigned __int64 uint64_t;
 #define STMT_FIND_QUES_ORDBY_CREATTM "find_ques_ordby_creattm"
 #define STMT_REMOVE_QUEATTRS "remove_queattrs"
 #define STMT_FIND_QUES_FROM_TIME_ORDBY_SAVETM "find_ques_from_time_ordby_savetm"
+#define STMT_UPDATE_QUE_AS_DELETED "update_que_status_as_deleted"
 
 /* node statement names */
 #define STMT_INSERT_NODE "insert_node"

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -118,6 +118,8 @@ que_alloc(char *name)
 	}
 	(void)memset((char *)pq, (int)0, (size_t)sizeof(pbs_queue));
 	pq->qu_qs.qu_type = QTYPE_Unset;
+	pq->qu_qs.qu_deleted = Q_Exist;
+	pq->qu_last_refresh_time = 0;
 	CLEAR_HEAD(pq->qu_jobs);
 	CLEAR_LINK(pq->qu_link);
 
@@ -249,12 +251,24 @@ que_purge(pbs_queue *pque)
 	}
 
 	/* delete queue from database */
-	strcpy(dbque.qu_name, pque->qu_qs.qu_name);
+	/*strcpy(dbque.qu_name, pque->qu_qs.qu_name);
 	obj.pbs_db_obj_type = PBS_DB_QUEUE;
 	obj.pbs_db_un.pbs_db_que = &dbque;
 	if (pbs_db_delete_obj(conn, &obj) != 0) {
 		(void)sprintf(log_buffer,
 			"delete of que %s from datastore failed",
+			pque->qu_qs.qu_name);
+		log_err(errno, "queue_purge", log_buffer);
+	}*/
+
+	/* for multi-server, update queue and mark it as deleted */
+	strcpy(dbque.qu_name, pque->qu_qs.qu_name);
+	dbque.qu_deleted = Q_Deleted;
+	obj.pbs_db_obj_type = PBS_DB_QUEUE;
+	obj.pbs_db_un.pbs_db_que = &dbque;
+	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_AS_DELETED) != 0) {
+		(void)sprintf(log_buffer,
+			"Marking queue as deleted %s from datastore failed",
 			pque->qu_qs.qu_name);
 		log_err(errno, "queue_purge", log_buffer);
 	}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
1. If queue is deleted by one server then other servers also needs to delete the same queue from memory and it's related objects.
2. queue is deleted from db but still some server showing it's stats from memory

#### Describe Your Change
1. Added a column to the pbs.queue table named as qu_deleted.
2. Update column with value 1 upon deletion else is 0.
3. During loading the queue from db if qu_deleted value is 1 this means que has been deleted already by other servers.
4. If que hasn't refreshed since from past one day then que will have to update oneself with the latest data from db. 

