### PR TITLE
Added locks during queue attr/resc set/unset

### DIFF
--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -179,9 +179,10 @@ extern pbs_queue *find_resvqueuebyname(char *);
 #endif /* localmod 075 */
 extern pbs_queue *get_dfltque(void);
 extern pbs_queue *que_alloc(char *name);
-extern void   que_free(pbs_queue *);
 extern pbs_queue *que_recov_db(char *, pbs_queue *, int);
-extern int    que_save_db(pbs_queue *, int mode);
+extern void      que_free(pbs_queue *);
+extern int       que_save_db(pbs_queue *, int mode);
+extern int       get_all_db_queues();
 
 #define QUE_SAVE_FULL 0
 #define QUE_SAVE_NEW  1

--- a/src/lib/Libdb/db_postgres_que.c
+++ b/src/lib/Libdb/db_postgres_que.c
@@ -118,6 +118,10 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 	if (pg_prepare_stmt(conn, STMT_SELECT_QUE, conn->conn_sql, 1) != 0)
 		return -1;
 
+	strcat(conn->conn_sql, " FOR UPDATE");
+	if (pg_prepare_stmt(conn, STMT_SELECT_QUE_LOCKED, conn->conn_sql, 1) != 0)
+		return -1;
+
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select qu_name, "
 			"qu_type, "
 			"qu_deleted, "
@@ -128,10 +132,6 @@ pg_db_prepare_que_sqls(pbs_db_conn_t *conn)
 			"where qu_savetm > to_timestamp($1, 'YYYY-MM-DD HH24:MI:SS:US') "
 			"order by qu_savetm ");
 	if (pg_prepare_stmt(conn, STMT_FIND_QUES_FROM_TIME_ORDBY_SAVETM, conn->conn_sql, 1) != 0)
-		return -1;
-
-	strcat(conn->conn_sql, " FOR UPDATE");
-	if (pg_prepare_stmt(conn, STMT_SELECT_QUE_LOCKED, conn->conn_sql, 1) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "

--- a/src/lib/Libdb/db_postgres_resv.c
+++ b/src/lib/Libdb/db_postgres_resv.c
@@ -142,6 +142,10 @@ pg_db_prepare_resv_sqls(pbs_db_conn_t *conn)
 	if (pg_prepare_stmt(conn, STMT_SELECT_RESV, conn->conn_sql, 1) != 0)
 		return -1;
 
+	strcat(conn->conn_sql, " FOR UPDATE");
+	if (pg_prepare_stmt(conn, STMT_SELECT_RESV_LOCKED, conn->conn_sql, 1) != 0)
+		return -1;
+
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
 		"ri_resvID, "
 		"ri_queue, "
@@ -164,10 +168,6 @@ pg_db_prepare_resv_sqls(pbs_db_conn_t *conn)
 		"from pbs.resv where ri_savetm > to_timestamp($1, 'YYYY-MM-DD HH24:MI:SS:US') "
 		"order by ri_savetm ");
 	if (pg_prepare_stmt(conn, STMT_FINDRESVS_FROM_TIME_ORDBY_SAVETM, conn->conn_sql, 1) != 0)
-		return -1;
-
-	strcat(conn->conn_sql, " FOR UPDATE");
-	if (pg_prepare_stmt(conn, STMT_SELECT_RESV_LOCKED, conn->conn_sql, 1) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -2201,11 +2201,13 @@ mark_which_queues_have_nodes()
 {
 	int		 i;
 	pbs_queue       *pque;
-
 	/* clear "has node" flag in all queues */
-
 	svr_quehasnodes = 0;
 
+	if (get_all_db_queues()) {
+		log_err(-1, __func__, "Failed to refresh queues from db");
+		/* TODO: Need to handle error here */
+	}
 	pque = (pbs_queue *)GET_NEXT(svr_queues);
 	while (pque != NULL) {
 		pque->qu_attr[(int)QE_ATR_HasNodes].at_val.at_long = 0;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -2099,8 +2099,12 @@ try_db_again:
 			}
 		}
 
+		/* refresh the queue list from db */
+		if (get_all_db_queues()) {
+			log_err(-1, __func__, "Failed to refresh queues from db");
+			/* TODO: Need to handle error here */
+		}
 		/* any jobs to route today */
-
 		pque = (pbs_queue *)GET_NEXT(svr_queues);
 		while (pque) {
 			if (pque->qu_qs.qu_type == QTYPE_RoutePush)

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -133,7 +133,7 @@ static int status_resv(resc_resv *, struct batch_request *, pbs_list_head *);
 extern pbs_sched *find_scheduler(char *sched_name);
 static int get_all_db_jobs();
 static int get_all_db_resvs();
-static int get_all_db_queues();
+int 	    get_all_db_queues();
 
 /**
  * @brief
@@ -494,7 +494,7 @@ get_all_db_jobs()
  * @return	0 - success
  * 			1 - fail/error
  */
-static int
+int
 get_all_db_queues() {
 	pbs_db_que_info_t	dbque;
 	pbs_db_obj_info_t	dbobj;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1906,6 +1906,11 @@ action_entlim_chk(attribute *pattr, void *pobject, int actmode)
 		log_mixed_limit_controls(NULL, i, "old");
 		return PBSE_MIXENTLIMS;
 	}
+	/* refresh the queue list from db */
+	if (get_all_db_queues()) {
+		log_err(-1, __func__, "Failed to refresh queues from db");
+		return 1;
+	}
 	pq = (pbs_queue *)GET_NEXT(svr_queues);
 	while (pq) {
 		if ((i=is_attrs_in_list_set(que_oldstyle, pq->qu_attr)) != -1) {
@@ -2134,6 +2139,13 @@ int actmode;
 		log_mixed_limit_controls(NULL, i, "new");
 		return PBSE_MIXENTLIMS;
 	}
+
+	/* refresh the queue list from db */
+	if (get_all_db_queues()) {
+		log_err(-1, __func__, "Failed to refresh queues from db");
+		return 1;
+	}
+
 	pq = (pbs_queue *)GET_NEXT(svr_queues);
 	while (pq) {
 		if ((i=is_attrs_in_list_set(que_newstyle, pq->qu_attr)) != -1) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1. Need to lock the queue row during set/unset resource or attribute.
2. Need to load all the queues from db before going to perform any operation on whole list of queues.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. Added lock during set/unset resource or attribute.
2. Added a call to get_all_db_queues() which will refresh all the queues data and also add queue if not present in memory. 

#### Attach Test and Valgrind Logs/Output
Smoke test result:  [ptl_smoke.txt](https://github.com/subhasisb/pbspro/files/3609306/ptl_smoke.txt)


