### PR TITLE
Job_sort_formula validation fixed

### DIFF
--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -1301,7 +1301,7 @@
    <attributes>	
    /* SRV_ATR_job_sort_formula */
 	<member_name><both>ATTR_job_sort_formula</both></member_name>
-	<member_at_decode>decode_str</member_at_decode>
+	<member_at_decode>decode_formula</member_at_decode>
 	<member_at_encode>encode_str</member_at_encode>
 	<member_at_set>set_str</member_at_set>
 	<member_at_comp>comp_str</member_at_comp>

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -1739,9 +1739,6 @@ decode_formula(attribute *patr, char *name, char *rescn, char *val)
 
 	fclose(fp);
 
-	/* now that we have the data, the file may be removed */
-	remove(pathbuf);
-
 	/* remove the newline */
 	formula_buf[strlen(formula_buf)-1] = '\0';
 


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
As the sched_formula file was deleted from server_priv after the job_sort_formula was loaded to memory. We were not able to decode the formula next time when it is saved in db and loaded to memory.



#### Describe Your Change

As a quick fix decode_str was used.  After analysing the issue found out that decode_formula was itself deleting the file after loading. That step is removed and decode_formula is used.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
