### PR TITLE
Making MoM aware of multi-server and honouring new parametes in pbs.conf file

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -290,7 +290,7 @@ struct batch_reply {
 #define PBS_BATCH_PySpawn	84
 #define PBS_BATCH_CopyHookFile	85
 #define PBS_BATCH_DelHookFile	86
-#define PBS_BATCH_MomRestart	87 /* Unused */
+#define PBS_BATCH_MomRestart	87 
 #define PBS_BATCH_AuthExternal	88
 #define PBS_BATCH_HookPeriodic  89
 #define PBS_BATCH_RelnodesJob	90
@@ -401,6 +401,8 @@ extern int DIS_wflush(int sock, int rpp);
 extern int engage_external_authentication(int out, int auth_type, int fromsvr, char *ebuf, int ebufsz);
 extern char *PBSD_modify_resv(int connect, char *resv_id,
 	struct attropl *attrib, char *extend);
+
+int initialise_connection_table(int table_size);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -290,7 +290,7 @@ struct batch_reply {
 #define PBS_BATCH_PySpawn	84
 #define PBS_BATCH_CopyHookFile	85
 #define PBS_BATCH_DelHookFile	86
-#define PBS_BATCH_MomRestart	87 
+#define PBS_BATCH_MomRestart	87 /* Unused */
 #define PBS_BATCH_AuthExternal	88
 #define PBS_BATCH_HookPeriodic  89
 #define PBS_BATCH_RelnodesJob	90

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -730,6 +730,9 @@ extern int pbs_delresv(int, char *, char *);
 extern int pbs_terminate(int, int, char *);
 
 extern char *pbs_modify_resv(int, char*, struct attropl *, char *);
+
+extern int (*internal_connect)(int, char *, int , char *);
+
 #endif /* _USRDLL */
 #ifdef	__cplusplus
 }

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -70,6 +70,7 @@
 #include "libsec.h"
 #include "pbs_ecl.h"
 #include "pbs_internal.h"
+#include "rpp.h"
 
 
 extern struct connect_handle connection[NCONNECTS];
@@ -686,7 +687,14 @@ tryagain:
 		} else if (connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_DOWN) {
 			/* connect and authenticate */
 			
-			sd = internal_tcp_connect(channel, pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port, NULL);
+			if (req_type != PBS_BATCH_MomRestart)
+				sd = internal_tcp_connect(channel, pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port, NULL);
+			else
+			{
+				sd = rpp_open(pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port);
+				connection[channel].ch_socket = sd; /* use the same socket for replies etc. */
+			}
+			
 			if (sd == -1) {
 				DBG_TRACE_SHARD((stderr, "Connect returned -1\n"))
 			   /* connection failed, check the error return 

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -91,7 +91,7 @@
 #include <netinet/tcp.h>
 #endif
 #include "pbs_error.h"
-
+#include "libpbs.h"
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>
 #endif
@@ -1535,6 +1535,54 @@ set_nodelay(int fd)
 
 	opt = 1;
 	return setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
+}
+
+
+int
+initialise_connection_table(int table_size)
+{
+	int i;
+	int j;
+
+	for (i=0; i < table_size; i++) {
+			if (connection[i].ch_inuse == 0) {
+				if (pbs_client_thread_lock_conntable() != 0)
+					return -1;
+
+				connection[i].ch_inuse = 1;
+				connection[i].ch_errno = 0;
+				connection[i].ch_socket= -1;
+				connection[i].ch_errtxt = NULL;
+				connection[i].shard_context = -1;
+
+				if (get_max_servers() > 1) {
+					if (connection[i].ch_shards == NULL) {
+						if (!(connection[i].ch_shards = calloc(get_current_servers(), sizeof(struct shard_conn *)))) {
+							pbs_errno = PBSE_SYSTEM;
+							connection[i].ch_inuse = 0;
+							return -1;
+						}
+						for (j = 0; j < get_current_servers(); j++) {
+							connection[i].ch_shards[j] = malloc(sizeof(struct shard_conn));
+							connection[i].ch_shards[j]->sd = -1;
+							connection[i].ch_shards[j]->state = SHARD_CONN_STATE_DOWN;
+							connection[i].ch_shards[j]->state_change_time = 0;
+							connection[i].ch_shards[j]->last_used = 0;
+						}
+
+					}
+
+				}
+
+				if (pbs_client_thread_unlock_conntable() != 0)
+					return -1;
+
+				return (i);
+			}
+		}
+
+		pbs_errno = PBSE_NOCONNECTS;
+		return (-1);
 }
 
 #endif /* malloc_info */


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* The current pbs_mom would always connect to default pbs_server(port 15001). 
* This default configuration wont support for multi-server setup with non-default ports.
* To avoid over subscribing the same service, now pbs_mom would connect to random service(using the get_svr_shard_connection() api for that)

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Added new api named get_server_stream() to get the stream to connect the random server, this api would initialize the connection table to multiple-servers.
* Modified the existing api get_svr_shard_connection() to use rpp_open() instead of internal_tcp_connect().

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Tested with multiple servers, 
With this change, now pbs_mom would get the random stream and update the node inventories.

[Mom_to_server_connections_test_logs copy.txt](https://github.com/subhasisb/pbspro/files/3729908/Mom_to_server_connections_test_logs.copy.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->