### PR TITLE
Added work task to delete objects from db and fixed some bugs

### DIFF
--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -626,11 +626,11 @@ void pbs_db_cursor_close(pbs_db_conn_t *conn, void *state);
  * @brief
  *	Get the number of rows from a cursor
  *
- * @param[in]	state - The opaque cusor state handle
+ * @param[in]	state - The opaque cursor state handle
  *
  * @return      int
  * @retval       0  - success
- * @retval      -1  - Failure
+ * @retval      -2  - Failure
  *
  */
 int pbs_db_get_rowcount(void *state);
@@ -673,6 +673,8 @@ int pbs_db_save_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
  * @param[in]	conn - Connected database handle
  * @param[in]	pbs_db_obj_info_t - Wrapper object that describes the object
  *              (and data) to delete
+ * @param[in]   pbs_db_query_options_t - Pointer to the options object that can
+ *		 contain the flags or timestamp which will effect the query.
  *
  * @return      int
  * @retval      -1  - Failure
@@ -680,7 +682,7 @@ int pbs_db_save_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
  * @retval       1 -  Success but no rows deleted
  *
  */
-int pbs_db_delete_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pbs_db_delete_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 /**
  * @brief

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -183,6 +183,11 @@ extern int       get_all_db_queues();
 #define QUE_SAVE_FULL 0
 #define QUE_SAVE_NEW  1
 
+/* after every 30 seconds, global list of server queues "svr_queues" updates from db see pbsd_main.c*/
+#define QUE_LOAD_INTERVAL 30
+/* 86400 secs = 1 day, objects has to refresh oneself atleast once in a day see: req_stat.c */
+#define OBJ_REFRESH_TIME_PERIOD 86400
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/lib/Libdb/db_postgres.h
+++ b/src/lib/Libdb/db_postgres.h
@@ -142,6 +142,7 @@ typedef unsigned __int64 uint64_t;
 #define STMT_REMOVE_QUEATTRS "remove_queattrs"
 #define STMT_FIND_QUES_FROM_TIME_ORDBY_SAVETM "find_ques_from_time_ordby_savetm"
 #define STMT_UPDATE_QUE_AS_DELETED "update_que_status_as_deleted"
+#define STMT_DELETE_ALL_QUE_AS_DELETED "delete_all_que_as_deleted"
 
 /* node statement names */
 #define STMT_INSERT_NODE "insert_node"
@@ -159,6 +160,7 @@ typedef unsigned __int64 uint64_t;
 #define STMT_UPDATE_NODEJOBATTRS "update_nodejob_attrs"
 #define STMT_FIND_NODES_ORDBY_INDEX_FILTERBY_SAVETM "find_nodes_ordby_index_filterby_savetm"
 #define STMT_UPDATE_NODE_AS_DELETED "update_nd_as_deleted"
+#define STMT_DELETE_ALL_NODE_AS_DELETED "delete_all_node_as_deleted"
 
 /* node job statements */
 #define STMT_SELECT_NODEJOB "select_nodejob"
@@ -229,7 +231,7 @@ typedef struct postgres_query_state pg_query_state_t;
  */
 struct postgres_db_fn {
 	int (*pg_db_save_obj)	(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
-	int (*pg_db_delete_obj)	(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+	int (*pg_db_delete_obj)	(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 	int (*pg_db_load_obj)	(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 	int (*pg_db_find_obj)	(pbs_db_conn_t *conn, void *state, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 	int (*pg_db_next_obj)	(pbs_db_conn_t *conn, void *state, pbs_db_obj_info_t *obj);
@@ -354,7 +356,7 @@ int pg_db_save_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_load_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 int pg_db_find_job(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_job(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 int pg_db_save_jobscr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_load_jobscr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
@@ -365,7 +367,7 @@ int pg_db_save_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_load_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 int pg_db_find_resv(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_resv(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 /* svr functions */
 int pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
@@ -376,7 +378,7 @@ int pg_db_save_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_load_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 int pg_db_find_node(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_node(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 /* mominfo_time functions */
 int pg_db_save_mominfo_tm(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
@@ -387,7 +389,7 @@ int pg_db_save_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_load_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 int pg_db_find_que(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_que(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_que(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 /* scheduler functions */
 int pg_db_save_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
@@ -395,7 +397,7 @@ int pg_db_load_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 
 int pg_db_find_sched(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_sched(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 int pg_db_del_attr_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pbs_db_attr_list_t *attr_list);
 int pg_db_del_attr_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void *obj_id, pbs_db_attr_list_t *attr_list);
@@ -412,7 +414,7 @@ int pg_db_load_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock);
 int pg_db_save_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype);
 int pg_db_find_nodejob(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 int pg_db_next_nodejob(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj);
-int pg_db_delete_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj);
+int pg_db_delete_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts);
 
 /* reset functions */
 void pg_db_reset_job(pbs_db_obj_info_t *obj);

--- a/src/lib/Libdb/db_postgres_impl.c
+++ b/src/lib/Libdb/db_postgres_impl.c
@@ -286,7 +286,9 @@ pbs_db_cursor_close(pbs_db_conn_t *conn, void *state)
  *
  * @param[in]	conn - Connected database handle
  * @param[in]	pbs_db_obj_info_t - Wrapper object that describes the object
- *		(and data) to delete
+ *		        (and data) to delete
+ * @param[in]	pbs_db_query_options_t - Pointer to the options object that can
+ *		contain the flags or timestamp which will effect the query.
  *
  * @return      int
  * @retval	-1  - Failure
@@ -295,9 +297,9 @@ pbs_db_cursor_close(pbs_db_conn_t *conn, void *state)
  *
  */
 int
-pbs_db_delete_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
+pbs_db_delete_obj(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts)
 {
-	return (db_fn_arr[obj->pbs_db_obj_type].pg_db_delete_obj(conn, obj));
+	return (db_fn_arr[obj->pbs_db_obj_type].pg_db_delete_obj(conn, obj, opts));
 }
 
 /**
@@ -344,7 +346,7 @@ pbs_db_cleanup_resultset(pbs_db_conn_t *conn)
  *
  * @return      Numer of rows in the cursor
  * @retval       0 or positive - Number of rows in cursor
- * @retval	-1  - Failure
+ * @retval	-2  - Failure
  *
  *
  */
@@ -354,7 +356,7 @@ pbs_db_get_rowcount(void *st)
 	pg_query_state_t *state = (pg_query_state_t *) st;
 	if (state)
 		return state->count;
-	return -1;
+	return -2;
 }
 
 /**

--- a/src/lib/Libdb/db_postgres_job.c
+++ b/src/lib/Libdb/db_postgres_job.c
@@ -643,6 +643,7 @@ pg_db_next_job(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  * @param[in]	conn - Connection handle
  * @param[in]	obj  - Job information
+ * @param[in]	opts - Optional arguments (i.e. timestamp or flags)
  *
  * @return      Error code
  * @retval	-1 - Failure
@@ -651,7 +652,7 @@ pg_db_next_job(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  */
 int
-pg_db_delete_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
+pg_db_delete_job(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts)
 {
 	pbs_db_job_info_t *pj = obj->pbs_db_un.pbs_db_job;
 	int rc = 0;

--- a/src/lib/Libdb/db_postgres_node.c
+++ b/src/lib/Libdb/db_postgres_node.c
@@ -230,6 +230,11 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 	if (pg_prepare_stmt(conn, STMT_UPDATE_MOMINFO_TIME, conn->conn_sql, 2) != 0)
 		return -1;
 
+	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "delete from pbs.node "
+			"where nd_deleted = 1 and 'localtimestamp - nd_savetm' > $1");
+	if (pg_prepare_stmt(conn, STMT_DELETE_ALL_NODE_AS_DELETED, conn->conn_sql, 1) != 0)
+		return -1;
+
 	return 0;
 }
 
@@ -473,6 +478,7 @@ pg_db_next_node(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  * @param[in]	conn - Connection handle
  * @param[in]	obj  - Node information
+ * @param[in]	opts - Optional arguments (i.e. timestamp or flags)
  *
  * @return      Error code
  * @retval	-1 - Failure
@@ -481,11 +487,19 @@ pg_db_next_node(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  */
 int
-pg_db_delete_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
+pg_db_delete_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts)
 {
 	pbs_db_node_info_t *pnd = obj->pbs_db_un.pbs_db_node;
-	SET_PARAM_STR(conn, pnd->nd_name, 0);
-	return (pg_db_cmd(conn, STMT_DELETE_NODE, 1));
+
+	if((opts->timestamp != NULL) && !(strcmp(pnd->nd_name, "DEL_ALL_NODES"))) {
+		/* delete all nodes whichever is marked as deleted(nd_deleted=1) */
+		SET_PARAM_STR(conn, opts->timestamp, 0);
+		return (pg_db_cmd(conn, STMT_DELETE_ALL_NODE_AS_DELETED, 1));
+	} else {
+		/* delete a single node by name(nd_name) */
+		SET_PARAM_STR(conn, pnd->nd_name, 0);
+		return (pg_db_cmd(conn, STMT_DELETE_NODE, 1));
+	}
 }
 
 

--- a/src/lib/Libdb/db_postgres_nodejob.c
+++ b/src/lib/Libdb/db_postgres_nodejob.c
@@ -385,6 +385,7 @@ pg_db_reset_nodejob(pbs_db_obj_info_t *obj)
  *
  * @param[in]	conn - Connection handle
  * @param[in]	obj  - Node information
+ * @param[in]	opts - Optional arguments (i.e. timestamp or flags)
  *
  * @return      Error code
  * @retval	-1 - Failure
@@ -393,7 +394,7 @@ pg_db_reset_nodejob(pbs_db_obj_info_t *obj)
  *
  */
 int
-pg_db_delete_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
+pg_db_delete_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts)
 {
 	pbs_db_nodejob_info_t *pnd = obj->pbs_db_un.pbs_db_nodejob;
 	SET_PARAM_STR(conn, pnd->job_id, 0);

--- a/src/lib/Libdb/db_postgres_resv.c
+++ b/src/lib/Libdb/db_postgres_resv.c
@@ -456,6 +456,7 @@ pg_db_next_resv(pbs_db_conn_t* conn, void* st, pbs_db_obj_info_t* obj)
  *
  * @param[in]	conn - Connection handle
  * @param[in]	obj  - Resv information
+ * @param[in]	opts - Optional arguments (i.e. timestamp or flags)
  *
  * @return      Error code
  * @retval	-1 - Failure
@@ -464,7 +465,7 @@ pg_db_next_resv(pbs_db_conn_t* conn, void* st, pbs_db_obj_info_t* obj)
  *
  */
 int
-pg_db_delete_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t* obj)
+pg_db_delete_resv(pbs_db_conn_t *conn, pbs_db_obj_info_t* obj, pbs_db_query_options_t *opts)
 {
 	pbs_db_resv_info_t *presv = obj->pbs_db_un.pbs_db_resv;
 	SET_PARAM_STR(conn, presv->ri_resvid, 0);

--- a/src/lib/Libdb/db_postgres_sched.c
+++ b/src/lib/Libdb/db_postgres_sched.c
@@ -423,6 +423,7 @@ pg_db_next_sched(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  * @param[in]	conn - Connection handle
  * @param[in]	obj  - scheduler information
+ * @param[in]	opts - Optional arguments (i.e. timestamp or flags)
  *
  * @return      Error code
  * @retval	-1 - Failure
@@ -431,7 +432,7 @@ pg_db_next_sched(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
  *
  */
 int
-pg_db_delete_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
+pg_db_delete_sched(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, pbs_db_query_options_t *opts)
 {
 	pbs_db_sched_info_t *sc = obj->pbs_db_un.pbs_db_sched;
 	SET_PARAM_STR(conn, sc->sched_name, 0);

--- a/src/server/job_func.c
+++ b/src/server/job_func.c
@@ -700,6 +700,7 @@ job_purge(job *pjob)
 	extern	char	*msg_err_purgejob_db;
 	pbs_db_obj_info_t obj;
 	pbs_db_job_info_t dbjob;
+	pbs_db_query_options_t opts;
 	pbs_db_nodejob_info_t db_nj;
 	pbs_db_conn_t *conn = (pbs_db_conn_t *) svr_db_conn;
 #endif	/* PBS_MOM */
@@ -923,7 +924,7 @@ job_purge(job *pjob)
 	obj.pbs_db_obj_type = PBS_DB_JOB;
 	obj.pbs_db_un.pbs_db_job = &dbjob;
 	strcpy(dbjob.ji_jobid, pjob->ji_qs.ji_jobid);
-	if (pbs_db_delete_obj(conn, &obj) == -1) {
+	if (pbs_db_delete_obj(conn, &obj, &opts) == -1) {
 		log_joberr(-1, __func__, msg_err_purgejob_db,
 			pjob->ji_qs.ji_jobid);
 	}
@@ -932,7 +933,7 @@ job_purge(job *pjob)
 	obj.pbs_db_obj_type = PBS_DB_NODEJOB;
 	obj.pbs_db_un.pbs_db_nodejob = &db_nj;
 	strcpy(db_nj.job_id, pjob->ji_qs.ji_jobid);
-	if (pbs_db_delete_obj(conn, &obj) == -1) {
+	if (pbs_db_delete_obj(conn, &obj, &opts) == -1) {
 		log_joberr(-1, __func__, msg_err_purgenodejob_db,
 			pjob->ji_qs.ji_jobid);
 	}
@@ -1715,6 +1716,7 @@ resv_purge(resc_resv *presv)
 	extern char *msg_purgeResvFail;
 	extern char *msg_purgeResvDb;
 	pbs_db_obj_info_t	obj;
+	pbs_db_query_options_t opts;
 	pbs_db_resv_info_t	dbresv;
 	pbs_db_nodejob_info_t db_nj;
 
@@ -1792,7 +1794,8 @@ resv_purge(resc_resv *presv)
 	strcpy(dbresv.ri_resvid, presv->ri_qs.ri_resvID);
 	obj.pbs_db_obj_type = PBS_DB_RESV;
 	obj.pbs_db_un.pbs_db_resv = &dbresv;
-	if (pbs_db_delete_obj(svr_db_conn, &obj) == -1) {
+
+	if (pbs_db_delete_obj(svr_db_conn, &obj, &opts) == -1) {
 		log_err(errno, __func__, msg_purgeResvDb);
 		(void) pbs_db_end_trx(svr_db_conn, PBS_DB_ROLLBACK);
 	}
@@ -1801,7 +1804,7 @@ resv_purge(resc_resv *presv)
 	obj.pbs_db_obj_type = PBS_DB_NODEJOB;
 	obj.pbs_db_un.pbs_db_nodejob = &db_nj;
 	strcpy(db_nj.job_id, presv->ri_qs.ri_resvID);
-	if (pbs_db_delete_obj(svr_db_conn, &obj) == -1) {
+	if (pbs_db_delete_obj(svr_db_conn, &obj, &opts) == -1) {
 		log_joberr(-1, __func__, msg_err_purgenodejob_db,
 			presv->ri_qs.ri_resvID);
 		(void) pbs_db_end_trx(svr_db_conn, PBS_DB_ROLLBACK);

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -212,10 +212,7 @@ db_to_svr_job(job *pjob,  pbs_db_job_info_t *dbjob)
 	strcpy(pjob->ji_qs.ji_jobid, dbjob->ji_jobid);
 	pjob->ji_qs.ji_state = dbjob->ji_state;
 	pjob->ji_qs.ji_substate = dbjob->ji_substate;
-	/* dbjob->ji_svrflags fetching wrong value from database, thus commented out.
-	 *  will fix it proper later.
-	 */
-	//pjob->ji_qs.ji_svrflags = dbjob->ji_svrflags;
+	pjob->ji_qs.ji_svrflags = dbjob->ji_svrflags;
 	pjob->ji_qs.ji_numattr = dbjob->ji_numattr ;
 	pjob->ji_qs.ji_ordering = dbjob->ji_ordering;
 	pjob->ji_qs.ji_priority = dbjob->ji_priority;

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -510,6 +510,7 @@ node_delete_db(struct pbsnode *pnode)
 	dbnode.nd_deleted = Obj_Deleted;
 	obj.pbs_db_obj_type = PBS_DB_NODE;
 	obj.pbs_db_un.pbs_db_node = &dbnode;
+
 	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_AS_DELETED) != 0) {
 		(void)sprintf(log_buffer,
 			"Marking node as deleted %s from datastore failed",

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -233,6 +233,7 @@ static int   attach_queue_to_reservation(resc_resv *);
 static void  call_log_license(struct work_task *);
 extern int create_resreleased(job *pjob);
 int am_i_resv_owner(char *);
+static void del_objects_from_db(struct work_task *);
 
 extern pbs_sched *sched_alloc(char *sched_name, int append);
 
@@ -1404,7 +1405,8 @@ pbsd_init(int type)
 #ifndef WIN32
 	(void)set_task(WORK_Immed, time_now, memory_debug_log, NULL);
 #endif /* !WIN32 */
-
+/* for multi-server project: create a  work task to delete the objects(job,queue,resv,node etc.) from the database */
+	(void)set_task(WORK_Timed, time_now + 1800, del_objects_from_db, NULL);
 	return (0);
 }
 
@@ -2174,4 +2176,53 @@ call_log_license(struct work_task *ptask)
 /* check the ownership of the reservtaion (i.e. servername)*/
 int am_i_resv_owner(char *resvid) {
 	return 1;
+}
+
+/**
+ * @brief
+ * 		del_que_from_db() - delete objects(job,que,resv etc.)from the database permanently
+ *
+ * @param[in]	ptask	- work task pointer
+ *
+ * @return	void
+ */
+void
+del_objects_from_db(struct work_task *ptask)
+{
+	/* delete all the objects (job,queue,resv,node etc) permanently from the db (only those objects which were marked
+	 * as deleted earlier)
+	 */
+	pbs_db_conn_t *conn = (pbs_db_conn_t *) svr_db_conn;
+	pbs_db_obj_info_t   obj;
+	pbs_db_query_options_t opts;
+	char time_buffer [6];
+	pbs_db_que_info_t   dbque;
+	pbs_db_node_info_t	dbnode;
+
+	/* delete all the queues(reservation and normal) */
+	sprintf(time_buffer, "%d", OBJ_REFRESH_TIME_PERIOD);
+	opts.timestamp = time_buffer;
+	strcpy(dbque.qu_name, "DEL_ALL_QUES");
+	obj.pbs_db_obj_type = PBS_DB_QUEUE;
+	obj.pbs_db_un.pbs_db_que = &dbque;
+	if (pbs_db_delete_obj(conn, &obj, &opts) != 0) {
+		log_err(-1, __func__, "deletion of queues from datastore failed");
+	}
+	pbs_db_reset_obj(&obj);
+
+	/* delete all the nodes */
+	strcpy(dbnode.nd_name, "DEL_ALL_NODES");
+	obj.pbs_db_obj_type = PBS_DB_NODE;
+	obj.pbs_db_un.pbs_db_node = &dbnode;
+	if (pbs_db_delete_obj(conn, &obj, &opts) != 0) {
+		log_err(-1, __func__, "deletion of nodes from datastore failed");
+	}
+
+	/*
+	 * TODO: write code to delete jobs from db permanently
+	 */
+
+	/* create a next occurence of the event after 30 minutes(1800 secs) */
+	if (ptask)
+		(void)set_task(WORK_Timed, time_now + 1800, del_objects_from_db, NULL);
 }

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -178,6 +178,7 @@ static void log_tppmsg(int level, const char *objname, char *mess);
 #define MAX_DB_RETRIES			20
 #define MAX_DB_LOOP_DELAY		1000000
 #define HOT_START_PING_RATE		15
+static time_t last_que_load_tm;
 
 /* Global Data Items */
 
@@ -2101,10 +2102,13 @@ try_db_again:
 			}
 		}
 
-		/* refresh the queue list from db */
-		if (get_all_db_queues()) {
-			log_err(-1, __func__, "Failed to refresh queues from db");
-			/* TODO: Need to handle error here */
+		if((time(0) - last_que_load_tm) > QUE_LOAD_INTERVAL) {
+			/* refresh the queue list from db */
+			if (get_all_db_queues()) {
+				log_err(-1, __func__, "Failed to refresh queues from db");
+				/* TODO: Need to handle error here */
+			}
+			last_que_load_tm = time(0);
 		}
 		/* any jobs to route today */
 		pque = (pbs_queue *)GET_NEXT(svr_queues);

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -250,19 +250,19 @@ que_purge(pbs_queue *pque)
 		}
 	}
 
-	/* for multi-server, update queue and mark it as deleted */
+	/* for multi-server, update queue and mark it as deleted to intimate other servers */
 	strcpy(dbque.qu_name, pque->qu_qs.qu_name);
 	dbque.qu_deleted = Obj_Deleted;
 	obj.pbs_db_obj_type = PBS_DB_QUEUE;
 	obj.pbs_db_un.pbs_db_que = &dbque;
+	/* it's a normal queue, mark it as deleted */
 	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_AS_DELETED) != 0) {
 		(void)sprintf(log_buffer,
-			"Marking queue as deleted %s from datastore failed",
+			"Marking queue as deleted %s in datastore failed",
 			pque->qu_qs.qu_name);
-		log_err(errno, "queue_purge", log_buffer);
+		log_err(-1, __func__, log_buffer);
 	}
 	que_free(pque);
-
 	return (0);
 }
 

--- a/src/server/queue_recov_db.c
+++ b/src/server/queue_recov_db.c
@@ -166,6 +166,7 @@ que_save_db(pbs_queue *pque, int mode)
 {
 	pbs_db_que_info_t	dbque;
 	pbs_db_obj_info_t	obj;
+	pbs_db_query_options_t opts;
 	pbs_db_conn_t		*conn = (pbs_db_conn_t *) svr_db_conn;
 	int savetype = PBS_UPDATE_DB_FULL;
 	int rc;
@@ -187,7 +188,7 @@ que_save_db(pbs_queue *pque, int mode)
 		if (rc == UNIQUE_KEY_VIOLATION) {
 			/* delete the existing queue with same name */
 			strcpy(dbque.qu_name, pque->qu_qs.qu_name);
-			if (pbs_db_delete_obj(conn, &obj) != 0) {
+			if (pbs_db_delete_obj(conn, &obj, &opts) != 0) {
 				(void)sprintf(log_buffer,
 					"deletetion of que %s from datastore failed after unique key violation",
 					pque->qu_qs.qu_name);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1344,6 +1344,7 @@ struct batch_request *preq;
 		pque = NULL;
 	} else {
 		(void)que_save_db(pque, QUE_SAVE_NEW);
+		// here we are saving server just to update queue count only, for more info check que_alloc() above */
 		(void)svr_save_db(&server, SVR_SAVE_FULL);
 		(void)sprintf(log_buffer, msg_manager, msg_man_cre,
 			preq->rq_user, preq->rq_host);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -88,6 +88,7 @@
 #include "resource.h"
 #include "pbs_sched.h"
 #include "pbs_share.h"
+#include <libpq-fe.h>
 
 #define REFRESH_TIME_PERIOD 86400
 
@@ -507,6 +508,7 @@ get_all_db_queues() {
 	int rc_cur = 0;
 	int refreshed = 0;
 	int count = 0;
+	int total_rows = 0;
 
 	if (pbs_db_begin_trx(conn, 0, 0) !=0) {
 		(void) pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
@@ -529,7 +531,17 @@ get_all_db_queues() {
 		return (1);
 	}
 
+	/* to get the number of rows returned by query */
+	if ((total_rows = pbs_db_get_rowcount(cur_state)) == -2) {
+		log_err(-1, __func__, "Failed to get count in resultset");
+	}
+
 	while ((rc_cur = pbs_db_cursor_next(conn, cur_state, &dbobj)) == 0) {
+		/* to save the last queue row save_tm */
+		if((total_rows - 1) == 0)
+			if(dbque.qu_savetm)
+				strcpy(ques_from_time, dbque.qu_savetm);
+
 		if ((pque = refresh_queue(&dbque, &refreshed)) == NULL) {
 			sprintf(log_buffer, "Failed to refresh queue %s", dbque.qu_name);
 			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
@@ -539,6 +551,7 @@ get_all_db_queues() {
 			count++;
 		}
 
+		total_rows --;
 		pbs_db_reset_obj(&dbobj);
 	}
 
@@ -546,8 +559,9 @@ get_all_db_queues() {
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
 		return (1);
 
-	if (pque)
-		strcpy(ques_from_time, pque->qu_savetm);
+	sprintf(log_buffer, "Refreshed %d queues", count);
+	log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, log_buffer);
+
 
 	return 0;
 }
@@ -676,8 +690,8 @@ req_stat_que(struct batch_request *preq)
 
 		pque = (pbs_queue *)GET_NEXT(svr_queues);
 		while (pque) {
-			if((time(0) - pque->qu_last_refresh_time) >= REFRESH_TIME_PERIOD) {
-				/* this que hasn't refreshed since from long time. Hence need to check it's existence.
+			if((time(0) - pque->qu_last_refresh_time) >= OBJ_REFRESH_TIME_PERIOD) {
+				/* this que hasn't refreshed since from long time(24 hrs.) hence need to check it's existence.
 				 * If it's been deleted by other server instance then remove from this server as well
 				 * and remove all the related jobs as well.
 				 */

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -169,6 +169,7 @@ sched_delete(pbs_sched *psched)
 {
 	pbs_db_obj_info_t obj;
 	pbs_db_sched_info_t dbsched;
+	pbs_db_query_options_t opts;
 	pbs_db_conn_t *conn = (pbs_db_conn_t *) svr_db_conn;
 
 	if (psched == NULL)
@@ -179,7 +180,7 @@ sched_delete(pbs_sched *psched)
 	strcpy(dbsched.sched_name, psched->sc_name);
 	obj.pbs_db_obj_type = PBS_DB_SCHED;
 	obj.pbs_db_un.pbs_db_sched = &dbsched;
-	if (pbs_db_delete_obj(conn, &obj) != 0) {
+	if (pbs_db_delete_obj(conn, &obj, &opts) != 0) {
 		snprintf(log_buffer, LOG_BUF_SIZE,
 				"delete of scheduler %s from datastore failed",
 				psched->sc_name);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
1. Server flag attribute was commented earlier due to value discrepancy during load from db is fixed now.
2. Added a timed task to delete all the queues(normal or resv) from the db and task will run after every 30 min as of now (we can change it later as per the requirements)
3. Fixed a bug in get_all_db_queues() in which if last que is marked as deleted in db then every time it was fetching all the queues instead of delta records.
4. Added a time interval of 30 secs in pbsd_main during get_all_db_queues() call.

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[ptl_smoketest.txt](https://github.com/subhasisb/pbspro/files/3742364/ptl_smoketest.txt)
