### PR TITLE
node object deletion with multi server

### DIFF
--- a/src/cmds/scripts/pbs_db_schema.sql
+++ b/src/cmds/scripts/pbs_db_schema.sql
@@ -94,13 +94,14 @@ CREATE TABLE pbs.mominfo_time (
  * Table pbs.node holds information about PBS nodes
  */
 CREATE TABLE pbs.node (
-    nd_name		    TEXT		NOT NULL,
+    nd_name		TEXT		NOT NULL,
     mom_modtime		BIGINT,
     nd_hostname		TEXT		NOT NULL,
     nd_state		INTEGER		NOT NULL,
     nd_ntype		INTEGER		NOT NULL,
-    nd_pque		    TEXT,
+    nd_pque		TEXT,
     nd_index		INTEGER		NOT NULL,
+    nd_deleted		INTEGER		NOT NULL default 0,
     nd_savetm		TIMESTAMP	NOT NULL,
     nd_creattm		TIMESTAMP	NOT NULL,
     attributes		hstore		NOT NULL default '',

--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -90,6 +90,10 @@ extern "C" {
 #define LOCK 1
 #define NO_LOCK 0
 
+/* for multi-server, given macros defines availability of Object */
+#define Obj_Exist 0
+#define Obj_Deleted 1
+
 /**
  * @brief
  *  Structure used to maintain the database connection information
@@ -278,6 +282,7 @@ struct pbs_db_node_info {
 	INTEGER nd_state;
 	INTEGER nd_ntype;
 	char	nd_pque[PBS_MAXSERVERNAME+1];
+	INTEGER nd_deleted;
 	char    nd_creattm[DB_TIMESTAMP_LEN + 1];
 	char    nd_savetm[DB_TIMESTAMP_LEN + 1];
 	pbs_db_attr_list_t attr_list; /* list of attributes */

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -294,7 +294,8 @@ struct	pbsnode {
 	char		nd_creatm[DB_TIMESTAMP_LEN + 1];		/* time queue created */
 	char		nd_savetm[DB_TIMESTAMP_LEN + 1];		/* time queue last modified */
 	struct memcache_state	trx_status;
-	attribute		 nd_attr[ND_ATR_LAST];
+	time_t		nd_last_refresh_time;				/* node last refresh time */
+	attribute	nd_attr[ND_ATR_LAST];
 };
 typedef struct pbsnode pbs_node;
 

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -458,7 +458,7 @@ extern	void	setup_notification(void);
 extern  struct	pbssubn  *find_subnodebyname(char *);
 extern	struct	pbsnode  *find_nodebyname(char *, int);
 extern	struct	pbsnode  *refresh_node(char *, char *, int);
-extern	int update_node_cache(pbs_node *);
+extern	int update_node_cache(pbs_node *, int);
 extern	int get_all_db_nodes();
 extern	struct	pbsnode  *find_nodebyaddr(pbs_net_t);
 extern	void	free_prop_list(struct prop*);

--- a/src/include/queue.h
+++ b/src/include/queue.h
@@ -61,10 +61,6 @@ extern "C" {
 #define QTYPE_RoutePush 2
 #define QTYPE_RoutePull 3
 
-/* for multi-server, given macros defines availability of queue */
-#define Q_Exist 0
-#define Q_Deleted 1
-
 /*
  * Attributes, including the various resource-lists are maintained in an
  * array in a "decoded or parsed" form for quick access to the value.

--- a/src/lib/Libdb/db_postgres.h
+++ b/src/lib/Libdb/db_postgres.h
@@ -158,6 +158,7 @@ typedef unsigned __int64 uint64_t;
 #define STMT_UPDATE_MOMINFO_TIME "update_mominfo_time"
 #define STMT_UPDATE_NODEJOBATTRS "update_nodejob_attrs"
 #define STMT_FIND_NODES_ORDBY_INDEX_FILTERBY_SAVETM "find_nodes_ordby_index_filterby_savetm"
+#define STMT_UPDATE_NODE_AS_DELETED "update_nd_as_deleted"
 
 /* node job statements */
 #define STMT_SELECT_NODEJOB "select_nodejob"

--- a/src/lib/Libdb/db_postgres_impl.c
+++ b/src/lib/Libdb/db_postgres_impl.c
@@ -409,6 +409,8 @@ pbs_db_begin_trx(pbs_db_conn_t *conn, int isolation_level, int async)
 {
 	PGresult *res;
 
+	DBPRT(("Entering: %s, conn->conn_trx_nest: %d", __func__, conn->conn_trx_nest))
+
 	if (conn->conn_trx_nest == 0) {
 		res = PQexec((PGconn *) conn->conn_db_handle, "BEGIN");
 		if (PQresultStatus(res) != PGRES_COMMAND_OK) {
@@ -462,6 +464,8 @@ pbs_db_end_trx(pbs_db_conn_t *conn, int commit)
 	char str[10] = "END";
 	PGresult *res;
 	int	rc = 0;
+
+	DBPRT(("Entering: %s, commit: %d, conn->conn_trx_nest: %d", __func__, commit, conn->conn_trx_nest))
 
 	if (conn->conn_trx_nest == 0)
 		return 0;

--- a/src/lib/Libdb/db_postgres_node.c
+++ b/src/lib/Libdb/db_postgres_node.c
@@ -72,15 +72,16 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state, "
 		"nd_ntype, "
 		"nd_pque, "
+		"nd_deleted, "
 		"nd_savetm, "
 		"nd_creattm, "
 		"attributes "
 		") "
 		"values "
-		"($1, $2, $3, $4, $5, $6, $7, localtimestamp, localtimestamp, hstore($8::text[])) "
+		"($1, $2, $3, $4, $5, $6, $7, $8, localtimestamp, localtimestamp, hstore($9::text[])) "
 		"returning to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm");
 
-	if (pg_prepare_stmt(conn, STMT_INSERT_NODE, conn->conn_sql, 8) != 0)
+	if (pg_prepare_stmt(conn, STMT_INSERT_NODE, conn->conn_sql, 9) != 0)
 		return -1;
 
 	/* in case of nodes do not use || with existing attributes, since we re-write all attributes */
@@ -91,11 +92,21 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state = $5, "
 		"nd_ntype = $6, "
 		"nd_pque = $7, "
+		"nd_deleted = $8, "
 		"nd_savetm = localtimestamp, "
-		"attributes = hstore($8::text[]) "
+		"attributes = hstore($9::text[]) "
 		" where nd_name = $1 "
 		"returning to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm");
 	if (pg_prepare_stmt(conn, STMT_UPDATE_NODE, conn->conn_sql, 8) != 0)
+		return -1;
+
+	/* update a nd_deleted attribute only */
+	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.node set "
+			"nd_deleted = $2, "
+			"nd_savetm = localtimestamp "
+			"where nd_name = $1 "
+			"returning to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm");
+	if (pg_prepare_stmt(conn, STMT_UPDATE_NODE_AS_DELETED, conn->conn_sql, 2) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.node set "
@@ -121,6 +132,7 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state, "
 		"nd_ntype, "
 		"nd_pque, "
+		"nd_deleted, "
 		"to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm, "
 		"to_char(nd_creattm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_creattm, "
 		"hstore_to_array(attributes) as attributes "
@@ -141,6 +153,7 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state, "
 		"nd_ntype, "
 		"nd_pque, "
+		"nd_deleted, "
 		"to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm, "
 		"to_char(nd_creattm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_creattm, "
 		"hstore_to_array(attributes) as attributes "
@@ -165,6 +178,7 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state, "
 		"nd_ntype, "
 		"nd_pque, "
+		"nd_deleted, "
 		"to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm, "
 		"to_char(nd_creattm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_creattm, "
 		"hstore_to_array(attributes) as attributes "
@@ -181,6 +195,7 @@ pg_db_prepare_node_sqls(pbs_db_conn_t *conn)
 		"nd_state, "
 		"nd_ntype, "
 		"nd_pque, "
+		"nd_deleted, "
 		"to_char(nd_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_savetm, "
 		"to_char(nd_creattm, 'YYYY-MM-DD HH24:MI:SS.US') as nd_creattm, "
 		"hstore_to_array(attributes) as attributes "
@@ -239,7 +254,7 @@ load_node(PGresult *res, pbs_db_node_info_t *pnd, int row)
 	char *raw_array;
 	char db_savetm[DB_TIMESTAMP_LEN + 1];
 	static int nd_name_fnum, mom_modtime_fnum, nd_hostname_fnum, nd_state_fnum, nd_ntype_fnum,
-	nd_pque_fnum, nd_svtime_fnum, nd_creattm_fnum, attributes_fnum;
+	nd_pque_fnum, nd_deleted_fnum, nd_svtime_fnum, nd_creattm_fnum, attributes_fnum;
 	static int fnums_inited = 0;
 
 	DBPRT(("Loading node from database"))
@@ -251,6 +266,7 @@ load_node(PGresult *res, pbs_db_node_info_t *pnd, int row)
 		nd_state_fnum = PQfnumber(res, "nd_state");
 		nd_ntype_fnum = PQfnumber(res, "nd_ntype");
 		nd_pque_fnum = PQfnumber(res, "nd_pque");
+		nd_deleted_fnum = PQfnumber(res,  "nd_deleted");
 		nd_svtime_fnum = PQfnumber(res, "nd_savetm");
 		nd_creattm_fnum = PQfnumber(res, "nd_creattm");
 		attributes_fnum = PQfnumber(res, "attributes");
@@ -272,6 +288,7 @@ load_node(PGresult *res, pbs_db_node_info_t *pnd, int row)
 	GET_PARAM_INTEGER(res, row, pnd->nd_state, nd_state_fnum);
 	GET_PARAM_INTEGER(res, row, pnd->nd_ntype, nd_ntype_fnum);
 	GET_PARAM_STR(res, row, pnd->nd_pque, nd_pque_fnum);
+	GET_PARAM_INTEGER(res, row, pnd->nd_deleted, nd_deleted_fnum);
 	GET_PARAM_STR(res, row, pnd->nd_creattm, nd_creattm_fnum);
 	GET_PARAM_BIN(res, row, raw_array, attributes_fnum);
 
@@ -302,26 +319,33 @@ pg_db_save_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	static int fnums_inited = 0;
 
 	SET_PARAM_STR(conn, pnd->nd_name, 0);
-	SET_PARAM_INTEGER(conn, pnd->nd_index, 1);
-	SET_PARAM_BIGINT(conn, pnd->mom_modtime, 2);
-	SET_PARAM_STR(conn, pnd->nd_hostname, 3);
-	SET_PARAM_INTEGER(conn, pnd->nd_state, 4);
-	SET_PARAM_INTEGER(conn, pnd->nd_ntype, 5);
-	SET_PARAM_STR(conn, pnd->nd_pque, 6);
-
-	if (savetype == PBS_UPDATE_DB_QUICK) {
-		params = 7;
+	if (savetype == PBS_UPDATE_DB_AS_DELETED) {
+		SET_PARAM_INTEGER(conn, pnd->nd_deleted, 1);
+		params = 2;
 	} else {
+		SET_PARAM_INTEGER(conn, pnd->nd_index, 1);
+		SET_PARAM_BIGINT(conn, pnd->mom_modtime, 2);
+		SET_PARAM_STR(conn, pnd->nd_hostname, 3);
+		SET_PARAM_INTEGER(conn, pnd->nd_state, 4);
+		SET_PARAM_INTEGER(conn, pnd->nd_ntype, 5);
+		SET_PARAM_STR(conn, pnd->nd_pque, 6);
+		SET_PARAM_INTEGER(conn, pnd->nd_deleted, 7);
+		params = 8;
+	}
+
+	if (savetype == PBS_UPDATE_DB_FULL || savetype == PBS_INSERT_DB) {
 		int len = 0;
 		/* convert attributes to postgres raw array format */
 		if ((len = convert_db_attr_list_to_array(&raw_array, &pnd->attr_list)) <= 0)
 			return -1;
 
-		SET_PARAM_BIN(conn, raw_array, len, 7);
-		params = 8;
+		SET_PARAM_BIN(conn, raw_array, len, 8);
+		params = 9;
 	}
 
-	if (savetype == PBS_UPDATE_DB_FULL)
+	if (savetype == PBS_UPDATE_DB_AS_DELETED)
+		stmt = STMT_UPDATE_NODE_AS_DELETED;
+	else if (savetype == PBS_UPDATE_DB_FULL)
 		stmt = STMT_UPDATE_NODE;
 	else
 		stmt = STMT_INSERT_NODE;

--- a/src/lib/Libdb/db_postgres_node.c
+++ b/src/lib/Libdb/db_postgres_node.c
@@ -391,7 +391,7 @@ pg_db_load_node(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock)
 	SET_PARAM_STR(conn, pnd->nd_name, 0);
 
 	if ((rc = pg_db_query(conn, STMT_SELECT_NODE, 1, lock, &res)) != 0)
-		return -1;
+		return rc;
 
 	rc = load_node(res, pnd, 0);
 

--- a/src/lib/Libdb/db_postgres_nodejob.c
+++ b/src/lib/Libdb/db_postgres_nodejob.c
@@ -152,8 +152,6 @@ load_nodejob(PGresult *res, pbs_db_nodejob_info_t *pnd, int row)
 	static int job_id_fnum, nd_name_fnum, is_resv_fnum, admn_suspend_fnum, attributes_fnum;
 	static int fnums_inited = 0;
 
-	DBPRT(("Entering %s", __func__))
-
 	if (fnums_inited == 0) {
 		job_id_fnum = PQfnumber(res, "job_id");
 		nd_name_fnum = PQfnumber(res, "nd_name");
@@ -202,8 +200,6 @@ pg_db_save_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	char *stmt;
 	int params;
 	char *raw_array = NULL;
-
-	DBPRT(("Entering %s", __func__))
 
 	SET_PARAM_STR(conn, pndjob->job_id, 0);
 	SET_PARAM_STR(conn, pndjob->nd_name, 1);
@@ -259,8 +255,6 @@ pg_db_add_update_attr_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, void 
 	int len = 0;
 	pbs_db_nodejob_info_t *pnj = obj->pbs_db_un.pbs_db_nodejob;
 
-	DBPRT(("Entering %s", __func__))
-
 	if ((len = convert_db_attr_list_to_array(&raw_array, attr_list)) <= 0)
 		return -1;
 	SET_PARAM_STR(conn, pnj->job_id, 0);
@@ -299,8 +293,6 @@ pg_db_load_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int lock)
 	int rc;
 	pbs_db_nodejob_info_t *pnj = obj->pbs_db_un.pbs_db_nodejob;
 
-	DBPRT(("Entering %s", __func__))
-
 	SET_PARAM_STR(conn, pnj->job_id, 0);
 	SET_PARAM_STR(conn, pnj->nd_name, 1);
 	if ((rc = pg_db_query(conn, STMT_SELECT_NODEJOB, 2, lock, &res)) != 0)
@@ -336,8 +328,6 @@ pg_db_find_nodejob(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj,
 	pg_query_state_t *state = (pg_query_state_t *) st;
 	pbs_db_nodejob_info_t *pnj = obj->pbs_db_un.pbs_db_nodejob;
 
-	DBPRT(("Entering %s", __func__))
-
 	if (!state)
 		return -1;
 
@@ -371,8 +361,6 @@ pg_db_next_nodejob(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
 	PGresult *res = ((pg_query_state_t *) st)->res;
 	pg_query_state_t *state = (pg_query_state_t *) st;
 
-	DBPRT(("Entering %s", __func__))
-
 	return (load_nodejob(res, obj->pbs_db_un.pbs_db_nodejob, state->row));
 }
 
@@ -388,7 +376,6 @@ pg_db_next_nodejob(pbs_db_conn_t *conn, void *st, pbs_db_obj_info_t *obj)
 void
 pg_db_reset_nodejob(pbs_db_obj_info_t *obj)
 {
-	DBPRT(("Entering %s", __func__))
 	free_db_attr_list(&(obj->pbs_db_un.pbs_db_nodejob->attr_list));
 }
 
@@ -408,7 +395,6 @@ pg_db_reset_nodejob(pbs_db_obj_info_t *obj)
 int
 pg_db_delete_nodejob(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
 {
-	DBPRT(("Entering %s", __func__))
 	pbs_db_nodejob_info_t *pnd = obj->pbs_db_un.pbs_db_nodejob;
 	SET_PARAM_STR(conn, pnd->job_id, 0);
 	return (pg_db_cmd(conn, STMT_DELETE_NODEJOB, 1));

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -173,44 +173,62 @@ extern int write_single_node_state(struct pbsnode *np);
 static void	remove_node_topology(char *);
 
 int
-update_node_cache(pbs_node *pnode)
+update_node_cache(pbs_node *pnode, int op)
 {
 	struct pbsnode **tmpndlist;
 
 	DBPRT(("Entering %s", __func__))
 
-	/* create node tree if not already done */
-	if (node_tree == NULL ) {
-		node_tree = create_tree(AVL_NO_DUP_KEYS, 0);
-		if (node_tree == NULL ) {
-			free_pnode(pnode);
-			return (PBSE_SYSTEM);
-		}
-	}
+	switch(op) {
+		case TREE_OP_ADD:
+			/* create node tree if not already done */
+			if (node_tree == NULL ) {
+				node_tree = create_tree(AVL_NO_DUP_KEYS, 0);
+				if (node_tree == NULL ) {
+					free_pnode(pnode);
+					return (PBSE_SYSTEM);
+				}
+			}
 
-	if (tree_add_del(node_tree, pnode->nd_name, pnode, TREE_OP_ADD) != 0) {
-		DBPRT(("Addition to node tree has failed"))
-		free_pnode(pnode);
-		return (PBSE_SYSTEM);
-	}
+			if (tree_add_del(node_tree, pnode->nd_name, pnode, op) != 0) {
+				DBPRT(("Addition to node tree has failed"))
+				free_pnode(pnode);
+				return (PBSE_SYSTEM);
+			}
 
-	/* expand pbsndlist array if not sufficient*/
-	if (pbsndlist_sz <= svr_totnodes) {
-		tmpndlist = (struct pbsnode **)realloc(pbsndlist,
-			sizeof(struct pbsnode*) * (svr_totnodes * 2 + 1));
+			/* expand pbsndlist array if not sufficient*/
+			if (pbsndlist_sz <= svr_totnodes) {
+				tmpndlist = (struct pbsnode **)realloc(pbsndlist,
+					sizeof(struct pbsnode*) * (svr_totnodes * 2 + 1));
 
-		if (tmpndlist != NULL) {
-			pbsndlist = tmpndlist;
-		} else {
-			free_pnode(pnode);
-			return (PBSE_SYSTEM);
-		}
-		pbsndlist_sz = svr_totnodes * 2 + 1;
+				if (tmpndlist != NULL) {
+					pbsndlist = tmpndlist;
+				} else {
+					free_pnode(pnode);
+					return (PBSE_SYSTEM);
+				}
+				pbsndlist_sz = svr_totnodes * 2 + 1;
+			}
+			/*add in the new entry etc*/
+			pnode->nd_index = svr_totnodes;
+			pnode->nd_arr_index = svr_totnodes; /* this is only in mem, not from db */
+			DBPRT(("pbsndlist_sz: %d, svr_totnodes: %d", pbsndlist_sz, svr_totnodes))
+			pbsndlist[svr_totnodes++] = pnode;
+			break;
+
+		case TREE_OP_DEL:
+			/* delete the node from the node tree as well as the node array */
+			if (node_tree != NULL && find_tree(node_tree, pnode->nd_name)) {
+				int	iht;
+				tree_add_del(node_tree, pnode->nd_name, NULL, TREE_OP_DEL);
+				for (iht=pnode->nd_arr_index + 1; iht < svr_totnodes; iht++) {
+					pbsndlist[iht - 1] = pbsndlist[iht];
+					/* adjust the arr_index since we are coalescing elements */
+					pbsndlist[iht - 1]->nd_arr_index--;
+				}
+				svr_totnodes--;
+			}
 	}
-	/*add in the new entry etc*/
-	pnode->nd_index = svr_totnodes;
-	pnode->nd_arr_index = svr_totnodes; /* this is only in mem, not from db */
-	pbsndlist[svr_totnodes++] = pnode;
 
 	return 0;
 }
@@ -245,7 +263,7 @@ refresh_node(char *nodename, char * nd_savetm, int lock)
 
 	if (pnode == NULL) {
 		if ((pnode = node_recov_db(nodename, pnode, lock)) != NULL) {
-			if (update_node_cache(pnode) != 0)
+			if (update_node_cache(pnode, TREE_OP_ADD) != 0)
 				return NULL;
 		}
 	} else if (!nd_savetm || strcmp(nd_savetm, pnode->nd_savetm) != 0) {
@@ -875,7 +893,6 @@ effective_node_delete(struct pbsnode *pnode)
 	struct pbssubn  *psubn;
 	struct pbssubn  *pnxt;
 	mom_svrinfo_t	*psvrmom;
-	int		 iht;
 	int		 socket_released = 0;
 
 	psubn = pnode->nd_psn;
@@ -938,18 +955,7 @@ effective_node_delete(struct pbsnode *pnode)
 	node_delete_db(pnode);
 
 	remove_node_topology(pnode->nd_name);
-
-	/* delete the node from the node tree as well as the node array */
-	if (node_tree != NULL) {
-		tree_add_del(node_tree, pnode->nd_name, NULL, TREE_OP_DEL);
-	}
-
-	for (iht=pnode->nd_arr_index + 1; iht < svr_totnodes; iht++) {
-		pbsndlist[iht - 1] = pbsndlist[iht];
-		/* adjust the arr_index since we are coalescing elements */
-		pbsndlist[iht - 1]->nd_arr_index--;
-	}
-	svr_totnodes--;
+	update_node_cache(pnode, TREE_OP_DEL);
 	free_pnode(pnode);
 	if (socket_released)
 		license_more_nodes();
@@ -1413,6 +1419,11 @@ setup_nodes()
 			goto db_err;
 		}
 		mom_modtime = dbnode.mom_modtime;
+
+		if (dbnode.nd_deleted) {
+			pbs_db_reset_obj(&obj);
+			continue;
+		}
 
 		/* now create node and subnodes */
 		pal = GET_NEXT(atrlist);

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -671,6 +671,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_nummslots = 1;
 	pnode->job_list = NULL;
 	pnode->resv_list = NULL;
+	pnode->nd_last_refresh_time = 0;
 
 	/* first, clear the attributes */
 

--- a/src/server/node_recov_db.c
+++ b/src/server/node_recov_db.c
@@ -191,7 +191,8 @@ node_recov_db(char *nd_name, struct pbsnode *pnode, int lock)
 
 	if (!pnode) {
 		pnode = malloc(sizeof(struct pbsnode));
-		initialize_pbsnode(pnode, nd_name, NTYPE_PBS);
+		initialize_pbsnode(pnode, strdup(nd_name), NTYPE_PBS);
+		DBPRT(("Initializing pbsnode..."))
 	} else {
 		if (memcache_good(&pnode->trx_status, lock))
 			return pnode;
@@ -206,11 +207,26 @@ node_recov_db(char *nd_name, struct pbsnode *pnode, int lock)
 	obj.pbs_db_obj_type = PBS_DB_NODE;
 	obj.pbs_db_un.pbs_db_node = &dbnode;
 
-	if (pbs_db_begin_trx(conn, 0, 0) != 0)
-		goto db_err;
+	if (lock)
+		if (pbs_db_begin_trx(conn, 0, 0) != 0)
+			goto db_err;
 
 	if ((rc = pbs_db_load_obj(conn, &obj, lock)) == -1)
 		goto db_err;
+
+	/* if queue is marked as deleted in db then remove it from cache also */
+	if (dbnode.nd_deleted == 1) {
+		if(pnode) {
+			sprintf(log_buffer, "Node marked as deleted");
+			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_DEBUG, nd_name, log_buffer);
+			/* TODO: Remove all the jobs, related to this queue in the system */
+			effective_node_delete(pnode);
+			if (lock)
+				(void)pbs_db_end_trx(conn,PBS_DB_COMMIT);
+			pbs_db_reset_obj(&obj);
+		}
+		return NULL;
+	}
 
 	if (rc == -2)
 		goto db_commit;
@@ -222,8 +238,7 @@ db_commit:
 	if (lock && pnode) {
 		pnode->nd_modified |= NODE_LOCKED;
 		memcache_update_state(&pnode->trx_status, lock);
-	} else
-		pbs_db_end_trx(conn, PBS_DB_COMMIT);
+	}
 
 	pbs_db_reset_obj(&obj);
 
@@ -285,6 +300,8 @@ svr_to_db_node(struct pbsnode *pnode, pbs_db_node_info_t *pdbnd)
 		strcpy(pdbnd->nd_pque, pnode->nd_pque->qu_qs.qu_name);
 	else
 		pdbnd->nd_pque[0]=0;
+
+	pdbnd->nd_deleted = 0;
 
 	/*
 	 * node attributes are saved in a different way than attributes of other objects
@@ -413,7 +430,6 @@ node_recov_db_raw(void *nd, pbs_list_head *phead)
 	return 0;
 }
 
-
 /**
  * @brief
  *	Save a node to the database. When we save a node to the database, delete
@@ -487,13 +503,18 @@ node_delete_db(struct pbsnode *pnode)
 	pbs_db_obj_info_t obj;
 	pbs_db_conn_t *conn = (pbs_db_conn_t *) svr_db_conn;
 
-	dbnode.nd_name[sizeof(dbnode.nd_name) - 1] = '\0';
-	strncpy(dbnode.nd_name, pnode->nd_name, sizeof(dbnode.nd_name));
+	/* for multi-server, update node and mark it as deleted */
+	strcpy(dbnode.nd_name, pnode->nd_name);
+	dbnode.nd_deleted = Obj_Deleted;
 	obj.pbs_db_obj_type = PBS_DB_NODE;
 	obj.pbs_db_un.pbs_db_node = &dbnode;
-
-	if (pbs_db_delete_obj(conn, &obj) == -1)
+	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_AS_DELETED) != 0) {
+		(void)sprintf(log_buffer,
+			"Marking node as deleted %s from datastore failed",
+			pnode->nd_name);
+		log_err(errno, __func__, log_buffer);
 		return (-1);
-	else
-		return (0);	/* "success" or "success but rows deleted" */
+	}
+
+	return (0);
 }

--- a/src/server/queue_func.c
+++ b/src/server/queue_func.c
@@ -118,7 +118,7 @@ que_alloc(char *name)
 	}
 	(void)memset((char *)pq, (int)0, (size_t)sizeof(pbs_queue));
 	pq->qu_qs.qu_type = QTYPE_Unset;
-	pq->qu_qs.qu_deleted = Q_Exist;
+	pq->qu_qs.qu_deleted = Obj_Exist;
 	pq->qu_last_refresh_time = 0;
 	CLEAR_HEAD(pq->qu_jobs);
 	CLEAR_LINK(pq->qu_link);
@@ -252,7 +252,7 @@ que_purge(pbs_queue *pque)
 
 	/* for multi-server, update queue and mark it as deleted */
 	strcpy(dbque.qu_name, pque->qu_qs.qu_name);
-	dbque.qu_deleted = Q_Deleted;
+	dbque.qu_deleted = Obj_Deleted;
 	obj.pbs_db_obj_type = PBS_DB_QUEUE;
 	obj.pbs_db_un.pbs_db_que = &dbque;
 	if (pbs_db_save_obj(conn, &obj, PBS_UPDATE_DB_AS_DELETED) != 0) {

--- a/src/server/queue_recov_db.c
+++ b/src/server/queue_recov_db.c
@@ -266,8 +266,8 @@ que_recov_db(char *qname, pbs_queue *pq, int lock)
 	/* if queue is marked as deleted in db then remove it from cache also */
 	if(dbque.qu_deleted == 1) {
 		if(pq) {
-			sprintf(log_buffer, "Queue %s marked as deleted", qname);
-			log_err(-1, __func__, log_buffer);
+			sprintf(log_buffer, "Queue marked as deleted");
+			log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_QUEUE, LOG_DEBUG, qname, log_buffer);
 			/* TODO: Remove all the jobs, related to this queue in the system */
 			que_free(pq);
 			pbs_db_reset_obj(&obj);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -3182,7 +3182,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 			return (PBSE_SYSTEM);
 		}
 
-		if (update_node_cache(pnode) != 0) {
+		if (update_node_cache(pnode, TREE_OP_ADD) != 0) {
 			free(pname);
 			return (PBSE_SYSTEM);
 		}

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -598,6 +598,8 @@ get_all_db_nodes() {
 		if ((pnode = refresh_node(dbnode.nd_name, dbnode.nd_savetm, NO_LOCK)) == NULL) {
 			sprintf(log_buffer, "Failed to refresh node %s", dbnode.nd_name);
 			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_NOTICE, msg_daemonname, log_buffer);
+		} else if (strncmp(pnode->nd_savetm, nodes_from_time, DB_TIMESTAMP_LEN) > 0) {
+			strcpy(nodes_from_time, pnode->nd_savetm);
 		}
 		pbs_db_reset_obj(&dbobj);
 	}
@@ -605,11 +607,6 @@ get_all_db_nodes() {
 	pbs_db_cursor_close(conn, cur_state);
 	if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0)
 		return (1);
-
-	if (pnode)
-		if (strncmp(pnode->nd_savetm, nodes_from_time, DB_TIMESTAMP_LEN) > 0)
-			strcpy(nodes_from_time, pnode->nd_savetm);
-		
 
 	return 0;
 }


### PR DESCRIPTION
As nodes are treated as a common object, another server should know if the node is deleted so that it can invalidate its cache. For that the nodes are marked as deleted in the DB so that other servers can fetch and invalidate its cache whenever a query is made. We also delete these nodes which are marked for deletion after T amount of time (24 hours now)
Future work:
Unlike queues, we dont have to load nodes in regular interval. That means there can be a server which does not have loaded a node during the last 24 hours during which it got deleted. This case needs to be addressed. 
This can be as simple as, during T/2 hours (where T is the time interval where object will get deleted from DB) every server should try to make sure nodes in its cache are not marked for deletion.