### PR TITLE
Appended an extra flag named as ATR_VFLAG_MODIFY

### DIFF
--- a/src/lib/Libpython/pbs_python_svr_internal.c
+++ b/src/lib/Libpython/pbs_python_svr_internal.c
@@ -3313,7 +3313,7 @@ _pps_helper_get_queue(pbs_queue *pque, const char *que_name)
 		que->qu_attr[(int)QA_ATR_TotalJobs].at_val.at_long = que->qu_numjobs -
 			(que->qu_njstate[JOB_STATE_MOVED] + que->qu_njstate[JOB_STATE_FINISHED] + que->qu_njstate[JOB_STATE_EXPIRED]);
 	}
-	que->qu_attr[(int)QA_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	que->qu_attr[(int)QA_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 	update_state_ct(&que->qu_attr[(int)QA_ATR_JobsByState],
 		que->qu_njstate,
@@ -3455,7 +3455,7 @@ _pps_helper_get_server(void)
 	server.sv_attr[(int)SRV_ATR_TotalJobs].at_val.at_long = \
 					server.sv_numjobs;
 	server.sv_attr[(int)SRV_ATR_TotalJobs].at_flags |= \
-					ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+					ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	update_state_ct(&server.sv_attr[(int)SRV_ATR_JobsByState],
 		server.sv_jobstates,
 		server.sv_jobstbuf);

--- a/src/resmom/mom_hook_func.c
+++ b/src/resmom/mom_hook_func.c
@@ -3265,7 +3265,7 @@ mom_process_hooks(unsigned int hook_event, char *req_user, char *req_host,
 				pjob->ji_qs.ji_un.ji_momt.ji_exitstat;
 			pjob->ji_wattr[(int)JOB_ATR_exit_status].\
 								at_flags |=
-				(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+				(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 			set_job_exit = 1;
 		} else if ((hook_event == HOOK_EVENT_EXECJOB_LAUNCH) && (num_run >= 1)) {
 

--- a/src/server/array_func.c
+++ b/src/server/array_func.c
@@ -587,7 +587,7 @@ update_subjob_state_ct(job *pjob)
 
 	pjob->ji_wattr[(int)JOB_ATR_array_state_count].at_val.at_str = buf;
 	pjob->ji_wattr[(int)JOB_ATR_array_state_count].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 }
 /**
  * @brief
@@ -705,7 +705,7 @@ setup_arrayjob_attrs(attribute *pattr, void *pobj, int mode)
 	/* set attribute "array" True  and clear "array_state_count" */
 
 	pjob->ji_wattr[(int)JOB_ATR_array].at_val.at_long = 1;
-	pjob->ji_wattr[(int)JOB_ATR_array].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int)JOB_ATR_array].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	job_attr_def[(int)JOB_ATR_array_state_count].at_free(&pjob->ji_wattr[(int)JOB_ATR_array_state_count]);
 
 	if ((mode == ATR_ACTION_NEW) || (mode == ATR_ACTION_RECOV)) {
@@ -940,7 +940,7 @@ create_subjob(job *parent, char *newjid, int *rc)
 #endif
 	/* set the queue rank attribute */
 	subj->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long = time_msec;
-	subj->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	subj->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	if (svr_enquejob(subj) != 0) {
 		job_purge(subj);
 		*rc = PBSE_IVALREQ;

--- a/src/server/attr_recov_db.c
+++ b/src/server/attr_recov_db.c
@@ -182,7 +182,7 @@ encode_attr_db(struct attribute_def *padef, struct attribute *pattr, int numattr
 		if ((pattr+i)->at_flags & ATR_DFLAG_NOSAVM)
 			continue;
 
-		if (!((all == 1) || ((pattr+i)->at_flags & (ATR_VFLAG_MODIFY | ATR_VFLAG_MODCACHE))))
+		if (!((all == 1) || ((pattr+i)->at_flags & ATR_VFLAG_MODIFY)))
 			continue;
 
 		rc = (padef+i)->at_encode(pattr+i, &lhead,

--- a/src/server/job_recov.c
+++ b/src/server/job_recov.c
@@ -166,7 +166,7 @@ job_save_fs(job *pjob, int updatetype)
 
 	if (pjob->ji_modified) {
 		pjob->ji_wattr[JOB_ATR_mtime].at_val.at_long = time_now;
-		pjob->ji_wattr[JOB_ATR_mtime].at_flags |= ATR_VFLAG_MODCACHE;
+		pjob->ji_wattr[JOB_ATR_mtime].at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 	}
 

--- a/src/server/job_recov_db.c
+++ b/src/server/job_recov_db.c
@@ -388,7 +388,7 @@ job_save_db(job *pjob, int updatetype)
 	/* if ji_modified is set, ie an attribute changed, then update mtime */
 	if (pjob->ji_modified) {
 		pjob->ji_wattr[JOB_ATR_mtime].at_val.at_long = time_now;
-		pjob->ji_wattr[JOB_ATR_mtime].at_flags |= ATR_VFLAG_MODCACHE;
+		pjob->ji_wattr[JOB_ATR_mtime].at_flags |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	}
 
 	if (pjob->ji_qs.ji_jsversion != JSVERSION) {
@@ -744,7 +744,7 @@ resv_save_db(resc_resv *presv, int updatetype)
 	/* if ji_modified is set, ie an attribute changed, then update mtime */
 	if (presv->ri_modified) {
 		presv->ri_wattr[RESV_ATR_mtime].at_val.at_long = time_now;
-		presv->ri_wattr[RESV_ATR_mtime].at_val.at_long |= ATR_VFLAG_MODCACHE;
+		presv->ri_wattr[RESV_ATR_mtime].at_val.at_long |= ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	}
 
 	if (svr_to_db_resv(presv, &dbresv, savetype) != 0)

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -708,7 +708,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 									(prd->rs_flags & ATR_DFLAG_MOM)) {
 			presc = add_resource_entry(pat2, prd);
 			presc->rs_value.at_flags = ATR_VFLAG_SET |
-				ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		}
 	}
 
@@ -1988,7 +1988,7 @@ node_pcpu_action(attribute *new, void *pobj, int actmode)
 		((prc->rs_value.at_flags & ATR_VFLAG_DEFLT) != 0)) {
 		if (prc->rs_value.at_val.at_long != new_np) {
 			prc->rs_value.at_val.at_long = new_np;
-			prc->rs_value.at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_DEFLT;
+			prc->rs_value.at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_DEFLT|ATR_VFLAG_MODIFY;
 			return (mod_node_ncpus(pnode, new_np, actmode));
 		}
 	}
@@ -2026,7 +2026,7 @@ mark_which_queues_have_nodes()
 	while (pque != NULL) {
 		pque->qu_attr[(int)QE_ATR_HasNodes].at_val.at_long = 0;
 		pque->qu_attr[(int)QE_ATR_HasNodes].at_flags &= ~ATR_VFLAG_SET;
-		pque->qu_attr[(int)QE_ATR_HasNodes].at_flags |= ATR_VFLAG_MODCACHE;
+		pque->qu_attr[(int)QE_ATR_HasNodes].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		pque = (pbs_queue *)GET_NEXT(pque->qu_link);
 	}
 
@@ -2035,7 +2035,7 @@ mark_which_queues_have_nodes()
 	for (i=0; i<svr_totnodes; i++) {
 		if (pbsndlist[i]->nd_pque) {
 			pbsndlist[i]->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_val.at_long = 1;
-			pbsndlist[i]->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			pbsndlist[i]->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			svr_quehasnodes = 1;
 		}
 	}

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -599,7 +599,7 @@ set_all_state(mominfo_t *pmom, int do_set, unsigned long bits, char *txt,
 			}
 		}
 
-		pvnd->nd_attr[(int)ND_ATR_state].at_flags |= ATR_VFLAG_MODCACHE;
+		pvnd->nd_attr[(int)ND_ATR_state].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		pat = &pvnd->nd_attr[(int)ND_ATR_Comment];
 
 		/*
@@ -728,7 +728,7 @@ node_down_requeue(struct work_task *pwt)
 						/* node is Mother Superior for job */
 						pj->ji_wattr[(int)JOB_ATR_exit_status].at_val.at_long = JOB_EXEC_RERUN_MS_FAIL;
 						pj->ji_wattr[(int)JOB_ATR_exit_status].at_flags |=
-							(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+							(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 						sprintf(log_buffer, msg_job_end_stat , JOB_EXEC_RERUN_MS_FAIL);
 						log_event(PBSEVENT_JOB, PBS_EVENTCLASS_JOB, LOG_INFO, pj->ji_qs.ji_jobid, log_buffer);
@@ -3551,7 +3551,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 							prs->rs_value.at_flags \
 							     &= ~ATR_VFLAG_DEFLT;
 							prs->rs_value.at_flags \
-							   |= ATR_VFLAG_MODCACHE;
+							   |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 							if (psrp->vna_val[0] != \
 									'\0') {
 								prs->rs_value.at_flags |= (ATR_VFLAG_SET|ATR_VFLAG_MODIFY);
@@ -3719,7 +3719,7 @@ update2_to_vnode(vnal_t *pvnal, int new, mominfo_t *pmom, int *madenew, int from
 					/* restart */
 
 					pattr->at_flags &= ~ATR_VFLAG_DEFLT;
-					pattr->at_flags |= ATR_VFLAG_MODCACHE;
+					pattr->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 					if (psrp->vna_val[0] != '\0') {
 						pattr->at_flags |= \
 					       (ATR_VFLAG_SET|ATR_VFLAG_MODIFY);
@@ -3892,7 +3892,7 @@ check_and_set_multivnode(struct pbsnode *pnode)
 				(*pala).at_val.at_long = 1;
 				(*pala).at_flags = \
 					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE |
-				ATR_VFLAG_DEFLT;
+				ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY;
 
 				/* DEFLT needed to reset on update */
 				pala = &pnode->nd_attr[
@@ -3900,7 +3900,7 @@ check_and_set_multivnode(struct pbsnode *pnode)
 				(*pala).at_val.at_long = 1;
 				(*pala).at_flags = \
 					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE |
-				ATR_VFLAG_DEFLT;
+				ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY;
 				break;
 			}
 		}
@@ -4043,7 +4043,7 @@ mom_running_jobs(int stream)
 					log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB, LOG_ALERT, pjob->ji_qs.ji_jobid, log_buffer);
 
 					pjob->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long = runver;
-					pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+					pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 					if (!(pjob->ji_wattr[(int)JOB_ATR_runcount].at_flags & ATR_VFLAG_SET) || (pjob->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long<=0)) {
 						pjob->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long = runver;
@@ -4400,7 +4400,7 @@ found:
 				np->nd_attr[(int)ND_ATR_pcpus].at_val.at_long =
 					psvrmom->msr_pcpus;
 				np->nd_attr[(int)ND_ATR_pcpus].at_flags |=
-					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			}
 
 			i = disrui(stream, &ret);	/* num of avail CPUs on host */
@@ -4493,7 +4493,7 @@ found:
 						prc->rs_value.at_val.at_long = i;
 						prc->rs_value.at_flags |= (ATR_VFLAG_SET |
 							ATR_VFLAG_MODCACHE |
-							ATR_VFLAG_DEFLT);
+							ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY);
 					}
 
 
@@ -4510,7 +4510,7 @@ found:
 						prc->rs_value.at_val.at_size.atsv_shift = 10;
 						prc->rs_value.at_flags |= (ATR_VFLAG_SET |
 							ATR_VFLAG_MODCACHE |
-							ATR_VFLAG_DEFLT);
+							ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY);
 					}
 				node_save_db(np);
 				}
@@ -4647,7 +4647,7 @@ found:
 					prc->rs_value.at_val.at_str = strdup(psvrmom->msr_arch);
 					prc->rs_value.at_flags |= (ATR_VFLAG_SET |
 						ATR_VFLAG_MODCACHE |
-						ATR_VFLAG_DEFLT);
+						ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY);
 				}
 
 				/*
@@ -4668,7 +4668,7 @@ found:
 						prc->rs_value.at_flags |=
 							(ATR_VFLAG_SET |
 							ATR_VFLAG_MODCACHE |
-							ATR_VFLAG_DEFLT);
+							ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY);
 					}
 					prd = find_resc_def(svr_resc_def, "mem",
 						svr_resc_size);
@@ -4682,7 +4682,7 @@ found:
 						prc->rs_value.at_val.at_size.atsv_shift = 10;
 						prc->rs_value.at_flags |= (ATR_VFLAG_SET |
 							ATR_VFLAG_MODCACHE |
-							ATR_VFLAG_DEFLT);
+							ATR_VFLAG_DEFLT | ATR_VFLAG_MODIFY);
 					}
 				}
 
@@ -4736,7 +4736,7 @@ found:
 
 					if (change || !(np->nd_attr[(int)ND_ATR_ResvEnable].at_flags & ATR_VFLAG_SET) || !(np->nd_attr[(int)ND_ATR_ResvEnable].at_flags & ATR_VFLAG_DEFLT))
 
-						np->nd_attr[(int)ND_ATR_ResvEnable].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE;
+						np->nd_attr[(int)ND_ATR_ResvEnable].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 				}
 
 				if (psvrmom->msr_pbs_ver != NULL) {
@@ -4870,7 +4870,7 @@ found:
 					if (hact == JOB_ACT_REQ_REQUEUE) {
 						pjob->ji_wattr[(int)JOB_ATR_exit_status].\
 						at_val.at_long = JOB_EXEC_HOOK_RERUN;
-						pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+						pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 						snprintf(log_buffer, sizeof(log_buffer),
 							"hook request rerun %s", jid);
 						log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
@@ -4878,7 +4878,7 @@ found:
 					} else if (hact == JOB_ACT_REQ_DELETE) {
 						pjob->ji_wattr[(int)JOB_ATR_exit_status].\
 						at_val.at_long = JOB_EXEC_HOOK_DELETE;
-						pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+						pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags |= (ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 						snprintf(log_buffer, sizeof(log_buffer),
 							"hook request delete %s", jid);
 						log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
@@ -6175,7 +6175,7 @@ update_FLic_attr(void)
 	if ((pbs_max_licenses - licenses.lb_used_floating) < pbs_float_lic->at_val.at_long)
 		pbs_float_lic->at_val.at_long = pbs_max_licenses - licenses.lb_used_floating;
 
-	pbs_float_lic->at_flags |= ATR_VFLAG_MODCACHE;
+	pbs_float_lic->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 }
 
 #define JBINXSZ_GROW 16;
@@ -7670,7 +7670,7 @@ update_job_node_rassn(void *obj, int is_resv, attribute *pexech, enum batch_op o
 					if (op == DECR) {
 						check_for_negative_resource(prdef, &pr->rs_value, NULL);
 					}
-					sysru->at_flags |= ATR_VFLAG_MODCACHE;
+					sysru->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 				}
 
 				/* update queue attribute of resources assigned */
@@ -7686,7 +7686,7 @@ update_job_node_rassn(void *obj, int is_resv, attribute *pexech, enum batch_op o
 					if (op == DECR) {
 						check_for_negative_resource(prdef, &pr->rs_value, NULL);
 					}
-					queru->at_flags |= ATR_VFLAG_MODCACHE;
+					queru->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 				}
 
 			}
@@ -7719,7 +7719,7 @@ update_job_node_rassn(void *obj, int is_resv, attribute *pexech, enum batch_op o
 				pr->rs_value.at_val.at_long += nchunk;
 			}
 			pr->rs_value.at_flags |= ATR_VFLAG_SET |
-				ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		}
 	}
 	if (queru) {
@@ -7734,7 +7734,7 @@ update_job_node_rassn(void *obj, int is_resv, attribute *pexech, enum batch_op o
 				pr->rs_value.at_val.at_long += nchunk;
 			}
 			pr->rs_value.at_flags |= ATR_VFLAG_SET |
-				ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		}
 	}
 	return;

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -266,54 +266,54 @@ init_server_attrs()
 
 	server.sv_attr[(int)SRV_ATR_State].at_val.at_long = SV_STATE_INIT;
 	server.sv_attr[(int)SRV_ATR_State].at_flags =
-		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_ResvEnable].at_val.at_long = 1;
 	server.sv_attr[(int)SRV_ATR_ResvEnable].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_SvrHost].at_val.at_str =strdup(server_host);
 	server.sv_attr[(int)SRV_ATR_SvrHost].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_NodeFailReq].at_val.at_long = PBS_NODE_FAIL_REQUEUE_DEFAULT;
 	server.sv_attr[(int)SRV_ATR_NodeFailReq].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SVR_ATR_maxarraysize].at_val.at_long = PBS_MAX_ARRAY_JOB_DFL;
 	server.sv_attr[(int)SVR_ATR_maxarraysize].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_license_min].at_val.at_long =
 		PBS_MIN_LICENSING_LICENSES;
 	server.sv_attr[(int)SRV_ATR_license_min].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_license_max].at_val.at_long =
 		PBS_MAX_LICENSING_LICENSES;
 	server.sv_attr[(int)SRV_ATR_license_max].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_license_linger].at_val.at_long = PBS_LIC_LINGER_TIME;
 	server.sv_attr[(int)SRV_ATR_license_linger].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SVR_ATR_FLicenses].at_val.at_long = 0;
 	server.sv_attr[(int)SVR_ATR_FLicenses].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_val.at_long = 0;
 	server.sv_attr[(int)SRV_ATR_EligibleTimeEnable].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_max_concurrent_prov].at_val.at_long =
 		PBS_MAX_CONCURRENT_PROV;
 	server.sv_attr[(int)SRV_ATR_max_concurrent_prov].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_max_job_sequence_id].at_val.at_ll = SVR_MAX_JOB_SEQ_NUM_DEFAULT;
 	server.sv_attr[(int)SRV_ATR_max_job_sequence_id].at_flags =
-		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	clear_attr(&attrib, &svr_attr_def[(int)	SVR_ATR_jobscript_max_size]);
 	svr_attr_def[(int)SVR_ATR_jobscript_max_size].at_decode(&attrib,ATTR_jobscript_max_size,NULL,DFLT_JOBSCRIPT_MAX_SIZE);
@@ -330,9 +330,9 @@ init_server_attrs()
 		if (presc) {
 			presc->rs_value.at_val.at_long = 1;
 			presc->rs_value.at_flags =
-				ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			server.sv_attr[(int)SVR_ATR_DefaultChunk].at_flags =
-				ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_DEFLT|ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			(void)deflt_chunk_action(
 				&server.sv_attr[(int)SVR_ATR_DefaultChunk],
 				(void *)&server, ATR_ACTION_NEW);
@@ -702,7 +702,7 @@ pbsd_init(int type)
 			server.sv_attr[(int)SRV_ATR_log_events].at_val.at_long =
 				new_log_event_mask;
 			server.sv_attr[(int)SRV_ATR_log_events].at_flags =
-				ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 		}
 		/* if server comment is a default, clear it */
@@ -794,7 +794,7 @@ pbsd_init(int type)
 			call_log_license, 0);
 
 	server.sv_attr[(int)SVR_ATR_FLicenses].at_val.at_long = licenses.lb_aval_floating + licenses.lb_glob_floating;
-	server.sv_attr[(int)SVR_ATR_FLicenses].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	server.sv_attr[(int)SVR_ATR_FLicenses].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	/* 6. open accounting file */
 
@@ -810,7 +810,7 @@ pbsd_init(int type)
 
 		server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long = a_opt;
 		server.sv_attr[(int)SRV_ATR_scheduling].at_flags |=
-			ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	}
 
 	/*
@@ -1579,7 +1579,7 @@ pbsd_init_job(job *pjob, int type)
 		/* Likely means recovering a job from a older version      */
 		if (((pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags & ATR_VFLAG_SET) == 0) && ((pjob->ji_wattr[(int)JOB_ATR_runcount].at_flags & ATR_VFLAG_SET) != 0)) {
 			pjob->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long = pjob->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long;
-			pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET & ATR_VFLAG_MODCACHE);
+			pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags |= (ATR_VFLAG_SET & ATR_VFLAG_MODCACHE & ATR_VFLAG_MODIFY);
 		}
 
 		if (pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) {
@@ -1822,7 +1822,7 @@ pbsd_init_reque(job *pjob, int change_state)
 	pjob->ji_wattr[(int)JOB_ATR_substate].at_val.at_long =
 		pjob->ji_qs.ji_substate;
 	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 
 	if ((rc = svr_enquejob(pjob)) == 0) {

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1323,7 +1323,7 @@ main(int argc, char **argv)
 	 */
 	server.sv_attr[(int)SRV_ATR_log_events].at_val.at_long = PBSEVENT_MASK;
 	server.sv_attr[(int)SRV_ATR_log_events].at_flags =
-		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	log_event_mask = &server.sv_attr[SRV_ATR_log_events].at_val.at_long;
 	(void)sprintf(path_log, "%s/%s", pbs_conf.pbs_home_path, PBS_LOGFILES);
 

--- a/src/server/req_delete.c
+++ b/src/server/req_delete.c
@@ -789,7 +789,7 @@ req_deletejob2(struct batch_request *preq, job *pjob)
 				 * Set exit status for the job to SIGKILL as we will not be working with any obit.
 				 */
 				pjob->ji_wattr[(int)JOB_ATR_exit_status].at_val.at_long = pjob->ji_qs.ji_un.ji_exect.ji_exitstat;
-				pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+				pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			}
 			/*
 			 * Check if the history of the finished job can be saved or it needs to be purged .

--- a/src/server/req_holdjob.c
+++ b/src/server/req_holdjob.c
@@ -185,7 +185,7 @@ req_holdjob(struct batch_request *preq)
 	hold_val = &pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long;
 	old_hold = *hold_val;
 	*hold_val |= temphold.at_val.at_long;
-	pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	/* Note the hold time in the job comment. */
 	now = time(NULL);
@@ -296,7 +296,7 @@ req_releasejob(struct batch_request *preq)
 		{
 			attribute *etime = &pjob->ji_wattr[(int)JOB_ATR_etime];
 			etime->at_val.at_long = time_now;
-			etime->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+			etime->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 #endif /* localmod 105 */
 		pjob->ji_modified = 1;	/* indicates attributes changed    */
 		svr_evaljobstate(pjob, &newstate, &newsub, 0);

--- a/src/server/req_jobobit.c
+++ b/src/server/req_jobobit.c
@@ -851,7 +851,7 @@ on_job_exit(struct work_task *ptask)
 			}
 
 			pjob->ji_wattr[(int)JOB_ATR_stageout_status].at_val.at_long = stageout_status;
-			pjob->ji_wattr[(int)JOB_ATR_stageout_status].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			pjob->ji_wattr[(int)JOB_ATR_stageout_status].at_flags = ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 			/*
 			 * files (generally) copied ok, move on to the next phase by
@@ -1876,7 +1876,7 @@ job_obit(struct resc_used_update *pruu, int stream)
 		pjob->ji_wattr[(int)JOB_ATR_exit_status].at_val.at_long = \
 								exitstatus;
 		pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags |=
-			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 	}
 
 	patlist = (svrattrl *)GET_NEXT(pruu->ru_attr);
@@ -2040,7 +2040,7 @@ job_obit(struct resc_used_update *pruu, int stream)
 
 				/* put job on password hold */
 				pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_bad_password;
-				pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+				pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 				pjob->ji_qs.ji_substate = JOB_SUBSTATE_HELD;
 				pjob->ji_modified = 1;
@@ -2102,7 +2102,7 @@ RetryJob:
 				) {
 					pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
 					pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |=
-						ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+						ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 					job_attr_def[(int)JOB_ATR_Comment].at_decode(
 						&pjob->ji_wattr[(int)JOB_ATR_Comment],
 						NULL, NULL,

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -656,7 +656,7 @@ set_queue_type(attribute *pattr, void *pque, int mode)
 			if (pattr->at_val.at_str == NULL)
 				return (PBSE_SYSTEM);
 			(void)strcpy(pattr->at_val.at_str, qt[i].name);
-			pattr->at_flags |= ATR_VFLAG_MODCACHE;
+			pattr->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			return (0);
 		}
 	}
@@ -2832,7 +2832,7 @@ mgr_node_unset(struct batch_request *preq)
 				}
 				if ((prc->rs_value.at_flags & ATR_VFLAG_SET) == 0) {
 					prc->rs_value.at_val.at_long = pnode->nd_ncpus;
-					prc->rs_value.at_flags |= ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+					prc->rs_value.at_flags |= ATR_VFLAG_DEFLT | ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 				}
 
 				/* If the Mom attribute is unset, reset to default */
@@ -3236,7 +3236,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 		pnode->nd_attr[(int)ND_ATR_Port].at_val.at_long =
 			pbs_mom_port;
 		pnode->nd_attr[(int)ND_ATR_Port].at_flags =
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	}
 
 	/* OK, set the attributes specified */
@@ -3577,7 +3577,7 @@ struct batch_request *preq;
 	if (pnode->nd_pque != NULL) {
 		pnode->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_val.at_long = 0;
 		pnode->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_flags &= ~ATR_VFLAG_SET;
-		pnode->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_flags |= ATR_VFLAG_MODCACHE;
+		pnode->nd_pque->qu_attr[(int)QE_ATR_HasNodes].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	}
 
 	(void)sprintf(log_buffer, msg_manager, msg_man_del,
@@ -5383,7 +5383,7 @@ resize_prov_table(int newsize)
 	server.sv_attr[(int)SRV_ATR_max_concurrent_prov].at_val.at_long =
 		newsize;
 	server.sv_attr[(int)SRV_ATR_max_concurrent_prov].at_flags =
-		(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+		(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 	svr_save_db(&server, SVR_SAVE_FULL);
 	return PBSE_NONE;
 }

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -238,9 +238,9 @@ req_orderjob(struct batch_request *req)
 	rank = pjob1->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long;
 	pjob1->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long =
 		pjob2->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long;
-	pjob1->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob1->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	pjob2->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long = rank;
-	pjob2->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob2->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	if (find_queuebyname(pjob1->ji_qs.ji_queue, 0) != find_queuebyname(pjob2->ji_qs.ji_queue, 0)) {
 		(void)strcpy(tmpqn, pjob1->ji_qs.ji_queue);

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -844,13 +844,13 @@ req_quejob(struct batch_request *preq)
 
 		pj->ji_wattr[(int)JOB_ATR_ctime].at_val.at_long =(long)time_now;
 		pj->ji_wattr[(int)JOB_ATR_ctime].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 		/* set hop count = 1 */
 
 		pj->ji_wattr[(int)JOB_ATR_hopcount].at_val.at_long = 1;
 		pj->ji_wattr[(int)JOB_ATR_hopcount].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 		/* need to set certain environmental variables per POSIX */
 
@@ -877,7 +877,7 @@ req_quejob(struct batch_request *preq)
 			pj->ji_wattr[(int)JOB_ATR_outpath].at_val.at_str =
 				prefix_std_file(pj, (int)'o');
 			pj->ji_wattr[(int)JOB_ATR_outpath].at_flags |=
-				ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		} else {
 			l = strlen(pj->ji_wattr[(int)JOB_ATR_outpath].at_val.at_str);
 			if (l > 0) {
@@ -897,7 +897,7 @@ req_quejob(struct batch_request *preq)
 			pj->ji_wattr[(int)JOB_ATR_errpath].at_val.at_str =
 				prefix_std_file(pj, (int)'e');
 			pj->ji_wattr[(int)JOB_ATR_errpath].at_flags |=
-				ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		} else {
 			l = strlen(pj->ji_wattr[(int)JOB_ATR_errpath].at_val.at_str);
 			if (l > 0) {
@@ -954,7 +954,7 @@ req_quejob(struct batch_request *preq)
 		/* increment hop count */
 
 		pj->ji_wattr[(int)JOB_ATR_hopcount].at_flags |=
-			ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		if (++pj->ji_wattr[(int)JOB_ATR_hopcount].at_val.at_long >
 			PBS_MAX_HOPCOUNT) {
 			job_purge(pj);
@@ -1081,7 +1081,7 @@ req_quejob(struct batch_request *preq)
 	pj->ji_wattr[(int)JOB_ATR_substate].at_val.at_long =
 		JOB_SUBSTATE_TRANSIN;
 	pj->ji_wattr[(int)JOB_ATR_substate].at_flags |=
-		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 
 	/* If this is a reservation job", "reserve_start", "reserve_end",
@@ -1129,7 +1129,7 @@ req_quejob(struct batch_request *preq)
 	pj->ji_wattr[(int)JOB_ATR_state].at_val.at_char = 'T';
 
 	pj->ji_wattr[(int)JOB_ATR_mtime].at_val.at_long = (long)time_now;
-	pj->ji_wattr[(int)JOB_ATR_mtime].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	pj->ji_wattr[(int)JOB_ATR_mtime].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 	pj->ji_qs.ji_un_type = JOB_UNION_TYPE_NEW;
 	pj->ji_qs.ji_un.ji_newt.ji_fromsock = sock;
@@ -1274,7 +1274,7 @@ req_quejob(struct batch_request *preq)
 			pjob->ji_wattr[(int)JOB_ATR_block].at_val.at_long = 0;
 			pjob->ji_wattr[(int)JOB_ATR_block].at_flags &= ~ATR_VFLAG_SET;
 			pjob->ji_wattr[(int)JOB_ATR_block].at_flags |=
-				ATR_VFLAG_MODCACHE;
+				ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 		}
 	}
@@ -1782,10 +1782,10 @@ req_commit_now(struct batch_request *preq, job *pj)
 	pj->ji_qs.ji_state = JOB_STATE_TRANSIT;
 	pj->ji_wattr[(int) JOB_ATR_state].at_val.at_char = 'T';
 	pj->ji_wattr[(int) JOB_ATR_state].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	pj->ji_qs.ji_substate = JOB_SUBSTATE_TRANSICM;
 	pj->ji_wattr[(int) JOB_ATR_substate].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 #ifdef PBS_MOM	/* MOM only */
 
@@ -1880,7 +1880,7 @@ req_commit_now(struct batch_request *preq, job *pj)
 	/* set the queue rank attribute */
 	pj->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long = time_msec;
 	pj->ji_wattr[(int)JOB_ATR_qrank].at_flags |=
-		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	/*
 	 * See if the job is qualified to go into the requested queue.
@@ -2412,7 +2412,7 @@ req_resvSub(struct batch_request *preq)
 		else  { /* If only 1 occurrence, treat it as an advance reservation */
 			presv->ri_wattr[RESV_ATR_resv_standing].at_val.at_long = 0;
 			presv->ri_wattr[RESV_ATR_resv_standing].at_flags |=\
-					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		}
 	}
 	(void)strcpy(presv->ri_qs.ri_resvID, rid);
@@ -2500,7 +2500,7 @@ req_resvSub(struct batch_request *preq)
 		presv->ri_wattr[(int)RESV_ATR_ctime]
 		.at_val.at_long =(long)time_now;
 		presv->ri_wattr[(int)RESV_ATR_ctime].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 		/* set hop count = 1 */
 		presv->ri_wattr[(int)RESV_ATR_hopcount].at_val.at_long = 1;

--- a/src/server/req_register.c
+++ b/src/server/req_register.c
@@ -793,7 +793,7 @@ set_depend_hold(job *pjob, attribute *pattr)
 		if ((pjob->ji_qs.ji_substate == JOB_SUBSTATE_SYNCHOLD) ||
 			(pjob->ji_qs.ji_substate == JOB_SUBSTATE_DEPNHOLD)) {
 			pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long &= ~HOLD_s;
-			pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_MODCACHE;
+			pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			svr_evaljobstate(pjob, &newstate, &newsubst, 0);
 			(void)svr_setjobstate(pjob, newstate, newsubst);
 		}
@@ -802,7 +802,7 @@ set_depend_hold(job *pjob, attribute *pattr)
 		/* there are dependencies, set system hold accordingly */
 
 		pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
-		pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		(void)svr_setjobstate(pjob, JOB_STATE_HELD, substate);
 	}
 	return;
@@ -863,7 +863,7 @@ static struct depend *make_depend(int type, attribute *pattr)
 	if (pdep) {
 		clear_depend(pdep, type, 0);
 		append_link(&pattr->at_val.at_list, &pdep->dp_link, pdep);
-		pattr->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+		pattr->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	}
 	return (pdep);
 }

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -196,7 +196,7 @@ check_and_provision_job(struct batch_request *preq, job *pjob, int *need_prov)
 		/* put system hold and move to held state */
 		pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
 		pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		(void)svr_setjobstate(pjob, JOB_STATE_HELD, JOB_SUBSTATE_HELD);
 		job_attr_def[(int)JOB_ATR_Comment].at_decode(
 			&pjob->ji_wattr[(int)JOB_ATR_Comment],
@@ -775,7 +775,7 @@ post_stagein(struct work_task *pwt)
 			pwait = &paltjob->ji_wattr[(int)JOB_ATR_exectime];
 			if ((pwait->at_flags & ATR_VFLAG_SET) == 0) {
 				pwait->at_val.at_long = time_now + PBS_STAGEFAIL_WAIT;
-				pwait->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+				pwait->at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 				(void)job_set_wait(pwait, paltjob, 0);
 			}
 			(void)svr_setjobstate(paltjob, JOB_STATE_WAITING,
@@ -963,7 +963,7 @@ svr_startjob(job *pjob, struct batch_request *preq)
 		delay = pque->qu_attr[(int)QE_ATR_KillDelay].at_val.at_long;
 	pjob->ji_wattr[(int)JOB_ATR_job_kill_delay].at_val.at_long = delay;
 	pjob->ji_wattr[(int)JOB_ATR_job_kill_delay].at_flags |=
-		(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+		(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 
 
 	/* Next, are there files to be staged-in? */
@@ -1035,10 +1035,10 @@ svr_strtjob2(job *pjob, struct batch_request *preq)
 	if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_CHKPT) == 0) {
 		++pjob->ji_wattr[(int)JOB_ATR_run_version].at_val.at_long;
 		pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags |=
-			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 		++pjob->ji_wattr[(int)JOB_ATR_runcount].at_val.at_long;
 		pjob->ji_wattr[(int)JOB_ATR_runcount].at_flags |=
-			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE);
+			(ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY);
 	}
 
 	/* send the job to MOM */
@@ -1126,7 +1126,7 @@ complete_running(job *jobp)
 			parent->ji_qs.ji_stime = time_now;
 			parent->ji_wattr[(int)JOB_ATR_stime].at_val.at_long = time_now;
 			parent->ji_wattr[(int)JOB_ATR_stime].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 			account_jobstr(parent);
 			job_attr_def[(int) JOB_ATR_Comment].at_decode(
@@ -1157,7 +1157,7 @@ complete_running(job *jobp)
 	jobp->ji_qs.ji_stime = time_now;
 	jobp->ji_wattr[(int)JOB_ATR_stime].at_val.at_long = time_now;
 	jobp->ji_wattr[(int)JOB_ATR_stime].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	/* compute an upper bound on job end time if possible */
 	if ((wall = get_wall(jobp)) != -1)
@@ -1564,7 +1564,7 @@ post_sendmom(struct work_task *pwt)
 						      at_val.at_long |= HOLD_s;
 						jobp->ji_wattr[(int)JOB_ATR_hold].\
 							at_flags |=
-							ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+							ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 						job_attr_def[(int)JOB_ATR_Comment].\
 						at_decode(\
 					  &jobp->ji_wattr[(int)JOB_ATR_Comment],

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -748,7 +748,7 @@ status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd)
 		pque->qu_attr[(int)QA_ATR_TotalJobs].at_val.at_long = pque->qu_numjobs -
 			(pque->qu_njstate[JOB_STATE_MOVED] + pque->qu_njstate[JOB_STATE_FINISHED] + pque->qu_njstate[JOB_STATE_EXPIRED]);
 	}
-	pque->qu_attr[(int)QA_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	pque->qu_attr[(int)QA_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 	update_state_ct(&pque->qu_attr[(int)QA_ATR_JobsByState],
 		pque->qu_njstate,
@@ -970,7 +970,7 @@ req_stat_svr(struct batch_request *preq)
 	/* update count and state counts from sv_numjobs and sv_jobstates */
 
 	server.sv_attr[(int)SRV_ATR_TotalJobs].at_val.at_long = server.sv_numjobs;
-	server.sv_attr[(int)SRV_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	server.sv_attr[(int)SRV_ATR_TotalJobs].at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 	update_state_ct(&server.sv_attr[(int)SRV_ATR_JobsByState],
 		server.sv_jobstates,
 		server.sv_jobstbuf);
@@ -1219,7 +1219,7 @@ update_state_ct(attribute *pattr, int *ct_array, char *buf)
 			*(ct_array + index));
 	}
 	pattr->at_val.at_str = buf;
-	pattr->at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	pattr->at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 }
 
 /**
@@ -1283,7 +1283,7 @@ update_license_ct(attribute *pattr, char *buf)
 		print_license_ct(last_valid_attempt, buf);
 
 	pattr->at_val.at_str = buf;
-	pattr->at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	pattr->at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 }
 
 /**

--- a/src/server/req_track.c
+++ b/src/server/req_track.c
@@ -301,7 +301,7 @@ track_history_job(struct rq_track *prqt, char *extend)
 		pjob->ji_wattr[(int)JOB_ATR_substate].at_val.at_long =
 			JOB_SUBSTATE_FINISHED;
 		pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |=
-			ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		/* over write the default comment message */
 		comment = "Job finished at";
 	}

--- a/src/server/resc_attr.c
+++ b/src/server/resc_attr.c
@@ -169,7 +169,7 @@ set_node_ct(resource *pnodesp, attribute *pattr, void *pobj, int type, int actmo
 
 	nn = ctnodes(pnodesp->rs_value.at_val.at_str);
 	pnct->rs_value.at_val.at_long = nn;
-	pnct->rs_value.at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE;
+	pnct->rs_value.at_flags |= ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY;
 
 	/* find the number of cpus specified in the node string */
 
@@ -202,7 +202,7 @@ set_node_ct(resource *pnodesp, attribute *pattr, void *pobj, int type, int actmo
 		/* ncpus is not set or not a new job (qalter being done) */
 		/* force ncpus to the correct thing */
 		pncpus->rs_value.at_val.at_long = nt;
-		pncpus->rs_value.at_flags |= (ATR_VFLAG_SET|ATR_VFLAG_MODCACHE);
+		pncpus->rs_value.at_flags |= (ATR_VFLAG_SET|ATR_VFLAG_MODCACHE|ATR_VFLAG_MODIFY);
 	}
 
 

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -493,7 +493,7 @@ set_resc_assigned(void *pobj, int objtype, enum batch_op op)
 						return;
 				}
 				rscdef->rs_set(&pr->rs_value, &rescp->rs_value, op);
-				sysru->at_flags |= ATR_VFLAG_MODCACHE;
+				sysru->at_flags |= ATR_VFLAG_MODCACHE  | ATR_VFLAG_MODIFY;
 			}
 
 			/* update queue attribute of resources assigned */
@@ -506,7 +506,7 @@ set_resc_assigned(void *pobj, int objtype, enum batch_op op)
 						return;
 				}
 				rscdef->rs_set(&pr->rs_value, &rescp->rs_value, op);
-				queru->at_flags |= ATR_VFLAG_MODCACHE;
+				queru->at_flags |= ATR_VFLAG_MODCACHE  | ATR_VFLAG_MODIFY;
 			}
 		}
 		rescp = (resource *)GET_NEXT(rescp->rs_link);
@@ -4662,7 +4662,7 @@ disable_svr_prov()
 		ATR_VFLAG_SET) {
 		server.sv_attr[(int)SRV_ATR_ProvisionEnable].at_val.at_long = 0;
 		server.sv_attr[(int)SRV_ATR_ProvisionEnable].at_flags
-		= ATR_VFLAG_MODCACHE | ATR_VFLAG_SET;
+		= ATR_VFLAG_MODCACHE | ATR_VFLAG_SET | ATR_VFLAG_MODIFY;
 	}
 }
 
@@ -5271,7 +5271,7 @@ fail_vnode_job(struct prov_vnode_info * prov_vnode_info, int hold_or_que)
 		clear_exec_on_run_fail(pjob);
 		pjob->ji_wattr[(int)JOB_ATR_hold].at_val.at_long |= HOLD_s;
 		pjob->ji_wattr[(int)JOB_ATR_hold].at_flags |=
-			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+			ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		job_attr_def[(int)JOB_ATR_Comment].at_decode(
 			&pjob->ji_wattr[(int)JOB_ATR_Comment],
 			NULL, NULL,
@@ -6063,11 +6063,11 @@ set_srv_prov_attributes(void)
 	server.sv_attr[(int)SVR_ATR_provision_timeout].at_val.at_long =
 		provision_timeout;
 	server.sv_attr[(int)SVR_ATR_provision_timeout].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	server.sv_attr[(int)SRV_ATR_ProvisionEnable].at_val.at_long=1;
 	server.sv_attr[(int)SRV_ATR_ProvisionEnable].at_flags |=
-		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+		ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 #else
 	disable_svr_prov();
 	DBPRT(("%s: Python not enabled\n", __func__))

--- a/src/server/svr_jobfunc.c
+++ b/src/server/svr_jobfunc.c
@@ -662,7 +662,7 @@ svr_setjobstate(job *pjob, int newstate, int newsubstate)
 	pjob->ji_qs.ji_state = newstate;
 	pjob->ji_qs.ji_substate = newsubstate;
 	pjob->ji_wattr[(int)JOB_ATR_substate].at_val.at_long = newsubstate;
-	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	set_statechar(pjob);
 	Update_Resvstate_if_resv(pjob);
@@ -1495,7 +1495,7 @@ check_block(job *pjob, char *message)
 	 * a reference to the fact that a history job was a blocking job . Port number need not be recorded .
 	 */
 	pjob->ji_wattr[(int) JOB_ATR_block].at_val.at_long = -1;
-	pjob->ji_wattr[(int) JOB_ATR_block].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int) JOB_ATR_block].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	pjob->ji_modified = 1;
 
 	phost = get_hostPart(pjob->ji_wattr[(int)JOB_ATR_job_owner].at_val.at_str);
@@ -2219,7 +2219,7 @@ set_chunk_sum(attribute  *pselectattr, attribute *pattr)
 			presc = add_resource_entry(pattr, pdef);
 		if (presc) {
 			presc->rs_value.at_val.at_long = total_chunks;
-			presc->rs_value.at_flags |= ATR_VFLAG_SET | ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE;
+			presc->rs_value.at_flags |= ATR_VFLAG_SET | ATR_VFLAG_DEFLT | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 		}
 	}
 	return 0;
@@ -2320,7 +2320,7 @@ set_deflt_resc(attribute *jb, attribute *dflt, int selflg)
 							SET) == 0)
 							prescjb->rs_value.at_flags |=
 								(ATR_VFLAG_SET|ATR_VFLAG_DEFLT);
-						jb->at_flags |= ATR_VFLAG_MODCACHE;
+						jb->at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 					}
 
 				}
@@ -2468,7 +2468,7 @@ set_statechar(job *pjob)
 	} else
 		pjob->ji_wattr[JOB_ATR_state].at_val.at_char =
 			*(statechars + pjob->ji_qs.ji_state);
-	pjob->ji_wattr[JOB_ATR_state].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[JOB_ATR_state].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 }
 
 /**
@@ -5013,7 +5013,7 @@ svr_clean_job_history(struct work_task *pwt)
 					pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_val.at_long =
 						pjob->ji_wattr[(int) JOB_ATR_stime].at_val.at_long + walltime_used;
 				}
-				pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+				pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 				pjob->ji_modified = 1;
 				/* save the full job */
 				(void)job_save(pjob, SAVEJOB_FULL);
@@ -5144,7 +5144,7 @@ svr_histjob_update(job * pjob, int newstate, int newsubstate)
 	}
 	/* set the substate attr and cache it */
 	pjob->ji_wattr[(int)JOB_ATR_substate].at_val.at_long = newsubstate;
-	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |= ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int)JOB_ATR_substate].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	/* save the full job */
 	(void)job_save(pjob, SAVEJOB_FULL);
@@ -5336,14 +5336,14 @@ svr_setjob_histinfo(job *pjob, histjob_type type)
 				pjob->ji_wattr[(int)JOB_ATR_stageout_status].at_val.at_long =
 					stgout_status;
 				pjob->ji_wattr[(int)JOB_ATR_stageout_status].at_flags =
-					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+					ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 			}
 			for (i=0; i<ptbl->tkm_ct; i++) {
 				if (ptbl->tkm_tbl[i].trk_exitstat) {
 					pjob->ji_wattr[(int)JOB_ATR_exit_status].at_val.at_long =
 						pjob->ji_qs.ji_un.ji_exect.ji_exitstat;
 					pjob->ji_wattr[(int)JOB_ATR_exit_status].at_flags =
-						ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+						ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 					break;
 				}
 			}
@@ -5390,7 +5390,7 @@ svr_setjob_histinfo(job *pjob, histjob_type type)
 
 	/* set the history timestamp */
 	pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_val.at_long = time_now;
-	pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE;
+	pjob->ji_wattr[(int) JOB_ATR_history_timestamp].at_flags |= ATR_VFLAG_SET | ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	pjob->ji_modified = 1;
 	/* update the history job state and substate */
 	svr_histjob_update(pjob, newstate, newsubstate);

--- a/src/server/svr_movejob.c
+++ b/src/server/svr_movejob.c
@@ -287,7 +287,7 @@ local_move(job *jobp, struct batch_request *req)
 	jobp->ji_qs.ji_queue[PBS_MAXQUEUENAME] = '\0';
 
 	jobp->ji_wattr[(int)JOB_ATR_qrank].at_val.at_long = time_now;
-	jobp->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE;
+	jobp->ji_wattr[(int)JOB_ATR_qrank].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 
 	pattr = &jobp->ji_wattr[(int)JOB_ATR_reserve_ID];
 	if (qp->qu_resvp) {
@@ -808,7 +808,7 @@ send_job(job *jobp, pbs_net_t hostaddr, int port, int move_type,
 		(move_type != MOVE_TYPE_Exec)) {
 		tempval = ((long)time_now - jobp->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long);
 		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long += tempval;
-		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_MODCACHE;
+		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	}
 
 	/* in windows code, a child process "w32_send_job" handles the send
@@ -1042,7 +1042,7 @@ send_job(job *jobp, pbs_net_t hostaddr, int port, int move_type,
 		(move_type != MOVE_TYPE_Exec)) {
 		tempval = ((long)time_now - jobp->ji_wattr[(int)JOB_ATR_sample_starttime].at_val.at_long);
 		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_val.at_long += tempval;
-		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_MODCACHE;
+		jobp->ji_wattr[(int)JOB_ATR_eligible_time].at_flags |= ATR_VFLAG_MODCACHE | ATR_VFLAG_MODIFY;
 	}
 
 	pattr = jobp->ji_wattr;


### PR DESCRIPTION
#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
1. Appended an extra flag **ATR_VFLAG_MODIFY** after **ATR_VFLAG_MODCACHE**
everywhere except **req_stat.c** file because i guess PBS never updates db through stat.
2. Removed **ATR_VFLAG_MODCACHE** check in **encode_attr_db** function so now onwards will save only those attributes which have  **ATR_VFLAG_MODIFY** flag enabled.

