### PR TITLE
nd_state shows initializing with multiple servers

### DIFF
--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -254,7 +254,6 @@ struct	pbssubn {
 
 struct	pbs_job_list {
 	char	*job_str;
-	ulong last_cpu_indx;
 	ulong buf_sz;
 	ulong offset;
 };
@@ -444,6 +443,7 @@ extern	void vnode_available(struct pbsnode *);
 extern	int find_degraded_occurrence(resc_resv *, struct pbsnode *, enum vnode_degraded_op);
 extern	int find_vnode_in_execvnode(char *, char *);
 extern	void set_vnode_state(struct pbsnode *, unsigned long , enum vnode_state_op);
+extern	void set_vnode_state2(struct pbsnode *, unsigned long , enum vnode_state_op, int);
 extern	struct resvinfo *find_vnode_in_resvs(struct pbsnode *, enum vnode_degraded_op);
 extern	void free_rinf_list(struct resvinfo *);
 extern	void degrade_offlined_nodes_reservations(void);

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -411,6 +411,8 @@ pre_nodejob_query(struct pbsnode *pnode)
 	resource   *prsc;
 	attribute    *pattr = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];
 
+	pnode->nd_nsnfree = pnode->nd_nsn;
+
 	/* clear all resc_assn values before reading afresh */
 	for (prsc = (resource *)GET_NEXT(pattr->at_val.at_list);
 			prsc != NULL;
@@ -439,14 +441,30 @@ pre_nodejob_query(struct pbsnode *pnode)
 void
 post_nodejob_query(struct pbsnode *pnode)
 {
-	resource   *prsc;
-	attribute    *pattr = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];
+	resource	*prsc;
+	attribute	*pattr = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];
+	long		share_node;
 
 	/* set the flags on another pass */
 	for (prsc = (resource *)GET_NEXT(pattr->at_val.at_list);
 			prsc != NULL;
 			prsc = (resource *)GET_NEXT(prsc->rs_link)) {
 		prsc->rs_value.at_flags |= ATR_VFLAG_SET;
+	}
+
+	/* set/unset state of node */
+	share_node = pnode->nd_attr[(int)ND_ATR_Sharing].at_val.at_long;
+	if (share_node == (int)VNS_FORCE_EXCL || share_node == (int)VNS_FORCE_EXCLHOST) {
+		set_vnode_state2(pnode, INUSE_JOBEXCL, Nd_State_Or, 0);
+	} else if (share_node == (int)VNS_IGNORE_EXCL) {
+		if (pnode->nd_nsnfree <= 0)
+			set_vnode_state2(pnode, INUSE_JOB, Nd_State_Or, 0);
+		else
+			set_vnode_state2(pnode, ~(INUSE_JOB | INUSE_JOBEXCL), Nd_State_And, 0);
+	} else if (pnode->nd_nsnfree <= 0) {
+		set_vnode_state2(pnode, INUSE_JOB, Nd_State_Or, 0);
+	} else if (pnode->nd_nsnfree == pnode->nd_nsn) {
+		set_vnode_state2(pnode, ~(INUSE_JOB | INUSE_JOBEXCL), Nd_State_And, 0);
 	}
 }
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -1140,21 +1140,28 @@ send_ip_addrs_to_mom(int stream)
  * @param[in]	pbsnode	- The vnode
  * @param[in]	state_bits	- the value to set the vnode to
  * @param[in]	type	- The operation on the node
+ * @param[in]	savedb	- tells whether to save into the db.
  *
  * @return	void
  *
  * @par MT-safe: No
  */
 void
-set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_state_op type)
+set_vnode_state2(struct pbsnode *pnode, unsigned long state_bits, enum vnode_state_op type, int save_db)
 {
 	unsigned long nd_prev_state;
 	int time_int_val;
+	int already_locked = 0;
 
 	time_int_val = time_now;
 
 	if (pnode == NULL)
 		return;
+
+	if (pnode->nd_modified & NODE_LOCKED || !save_db)
+		already_locked = 1;
+	else
+		pnode = find_nodebyname(pnode->nd_name, LOCK);
 
 	nd_prev_state = pnode->nd_state;
 	switch (type) {
@@ -1193,6 +1200,9 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 		set_attr_svr(&(pnode->nd_attr[(int)ND_ATR_last_state_change_time]),
 			&node_attr_def[(int) ND_ATR_last_state_change_time], str_val);
 	}
+
+	if(!already_locked)
+		node_save_db(pnode);
 
 	if (pnode->nd_state & INUSE_PROV) {
 		if (!(pnode->nd_state & VNODE_UNAVAILABLE) ||	
@@ -1245,6 +1255,29 @@ set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_stat
 		((!(pnode->nd_state & VNODE_UNAVAILABLE)) ||
 		(pnode->nd_state == INUSE_FREE)))
 		(void) vnode_available(pnode);
+}
+
+/**
+ * @brief
+ * 		Change the state of a vnode. See pbs_nodes.h for definition of node's
+ * 		availability and unavailability.
+ *
+ * 		This function detects the type of change, either from available to
+ * 		unavailable, and invokes the appropriate handler to handle the state
+ * 		change.
+ *
+ * @param[in]	pbsnode	- The vnode
+ * @param[in]	state_bits	- the value to set the vnode to
+ * @param[in]	type	- The operation on the node
+ *
+ * @return	void
+ *
+ * @par MT-safe: No
+ */
+void
+set_vnode_state(struct pbsnode *pnode, unsigned long state_bits, enum vnode_state_op type)
+{
+	set_vnode_state2(pnode, state_bits, type, 1);
 }
 
 /**
@@ -7044,31 +7077,15 @@ set_nodes(void *pobj, int objtype, char *execvnod_in, char **execvnod_out, char 
 						pnode->nd_nsnfree))
 				}
 			}
+
 			share_node = pnode->nd_attr[(int)ND_ATR_Sharing].at_val.at_long;
-			if (share_node == (int)VNS_FORCE_EXCL || share_node == (int)VNS_FORCE_EXCLHOST) {
-				set_vnode_state(pnode, INUSE_JOBEXCL, Nd_State_Or);
-			} else if (share_node == (int)VNS_IGNORE_EXCL) {
-				if (pnode->nd_nsnfree <= 0)
-					set_vnode_state(pnode, INUSE_JOB, Nd_State_Or);
-				else
-					set_vnode_state(pnode, ~(INUSE_JOB | INUSE_JOBEXCL), Nd_State_And);
-			} else if (share_node == (int)VNS_DFLT_EXCL || share_node == (int)VNS_DFLT_EXCLHOST) {
-				if (share_job == (int)VNS_IGNORE_EXCL) {
-					if (pnode->nd_nsnfree <= 0)
-						set_vnode_state(pnode, INUSE_JOB, Nd_State_Or);
-					else
-						set_vnode_state(pnode, ~(INUSE_JOB | INUSE_JOBEXCL), Nd_State_And);
-				} else {
+			if (share_node == (int)VNS_DFLT_EXCL || share_node == (int)VNS_DFLT_EXCLHOST) {
+				if (share_job != (int)VNS_IGNORE_EXCL) {
 					set_vnode_state(pnode, INUSE_JOBEXCL, Nd_State_Or);
 				}
 			} else if (share_job == VNS_FORCE_EXCL) {
 				set_vnode_state(pnode, INUSE_JOBEXCL, Nd_State_Or);
-			} else if (pnode->nd_nsnfree <= 0) {
-				set_vnode_state(pnode, INUSE_JOB, Nd_State_Or);
-			} else {
-				set_vnode_state(pnode, ~(INUSE_JOB | INUSE_JOBEXCL), Nd_State_And);
 			}
-
 
 			/*
 			 * now for each new chunk, add the job to the Mom job index

--- a/src/server/nodejob_recov_db.c
+++ b/src/server/nodejob_recov_db.c
@@ -168,7 +168,6 @@ append_to_joblist(pbs_node *pnode, char *jobid, int ncpus)
 		pnode->job_list->job_str = malloc(1024);
 		pnode->job_list->buf_sz = 1024;
 		pnode->job_list->offset = 0;
-		pnode->job_list->last_cpu_indx = 0;
 	}
 	
 	jlist = pnode->job_list;
@@ -185,9 +184,9 @@ append_to_joblist(pbs_node *pnode, char *jobid, int ncpus)
 			jlist->offset +=sprintf(jlist->job_str + jlist->offset, ", ");
 		}
 		jlist->offset += sprintf(jlist->job_str + jlist->offset,
-					 "%s/%ld", jobid, jlist->last_cpu_indx);
+					 "%s/%ld", jobid, pnode->nd_nsn - pnode->nd_nsnfree);
 		if (ncpus)
-			jlist->last_cpu_indx += 1;
+			pnode->nd_nsnfree -= 1;
 	} while(--ncpus > 0);
 }
 
@@ -203,7 +202,6 @@ append_to_resvlist(pbs_node *pnode, char *resvid)
 		pnode->resv_list->job_str = malloc(1024);
 		pnode->resv_list->buf_sz = 1024;
 		pnode->resv_list->offset = 0;
-		pnode->resv_list->last_cpu_indx = 0;
 	}
 	
 	rlist = pnode->resv_list;
@@ -233,8 +231,6 @@ nodejob_db_to_attrlist(struct pbsnode *pnode, pbs_db_nodejob_info_t *db_obj)
 		attribute tmpattr;
 		pbs_db_attr_info_t *attrs = &db_obj->attr_list.attributes[i];
 
-		if (strcmp(attrs->attr_name, ATTR_rescassn))
-			continue;
 		memset(&tmpattr, 0, sizeof(attribute));
 		if ((node_attr_def + ND_ATR_ResourceAssn)->at_decode) {
 			(void)(node_attr_def + ND_ATR_ResourceAssn)->at_decode(


### PR DESCRIPTION
* save node state if already not locked for writing in set_vnode_state()
* remove part of the logic from set_nodes() to stat_nodes where it calculates the state to offload the job run path.