### PR TITLE
POC for making mom to connect multi-server

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -407,7 +407,7 @@ extern int DIS_wflush(int sock, int rpp);
 extern int engage_external_authentication(int out, int auth_type, int fromsvr, char *ebuf, int ebufsz);
 extern char *PBSD_modify_resv(int connect, char *resv_id,
 	struct attropl *attrib, char *extend);
-int initialise_connection_slot(int table_size);
+extern int initialise_connection_slot(int table_size);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -294,6 +294,7 @@ void convert_duration_to_str(time_t duration, char* buf, int bufsize);
 int get_max_servers();
 int get_current_servers();
 int get_my_index();
+int get_svr_index(int port);
 long long get_next_hash(long long curr, long long max_id);
 long long get_last_hash(long long njobid);
 int get_server_shard(char * shard_hint);

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -732,6 +732,9 @@ extern int pbs_terminate(int, int, char *);
 extern int pbs_sched_cycle_end(int c, char *scname, int start_or_end, char *extend);
 
 extern char *pbs_modify_resv(int, char*, struct attropl *, char *);
+
+extern int (*internal_connect)(int, char *, int , char *);
+
 #endif /* _USRDLL */
 #ifdef	__cplusplus
 }

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -78,6 +78,7 @@ extern struct connect_handle connection[NCONNECTS];
 
 #define DBG_TRACE_SHARD(x) { if (getenv("DBG_TRACE_SHARD")) { fprintf x;}}
 
+int (*internal_connect)(int, char *, int , char *) = NULL;
 /**
  * @brief
  *	-returns the default server name.
@@ -637,12 +638,19 @@ set_new_shard_context(int channel)
 	DBG_TRACE_SHARD((stderr, "*** Set new shard ***\n"))
 }
 
+int internal_connect_cli(int channel, char *server, int port, char *extend_data)
+{
+	return internal_tcp_connect(channel, server, port, NULL);
+}
+
 int 
 get_svr_shard_connection(int channel, int req_type, void *shard_hint)
 {
 	int srv_index;
 	int sd;
 	int first_index = -1;
+	if (internal_connect == NULL)
+		internal_connect = internal_connect_cli;
 
 	if (pbs_conf.pbs_max_servers > 1) {
 		if (connection[channel].shard_context == -1) {
@@ -687,7 +695,8 @@ tryagain:
 			} else if (connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_DOWN) {
 				/* connect and authenticate */
 
-				sd = internal_tcp_connect(channel, pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port, NULL);
+				sd = internal_connect(channel, pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port, NULL);
+				connection[channel].ch_socket = sd; /* use the same socket for replies etc. */
 				if (sd == -1) {
 					DBG_TRACE_SHARD((stderr, "Connect returned -1\n"))
 				   /* connection failed, check the error return
@@ -716,6 +725,7 @@ tryagain:
 			if ( connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_CONNECTED)
 				return  connection[channel].ch_shards[srv_index]->sd;
 			else {
+				connection[channel].conn_exists = 0;
 				goto tryagain;
 			}
 		}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -113,6 +113,7 @@ struct {
 	{ND_Force_Exclhost,   VNS_FORCE_EXCLHOST}
 };
 
+int initialise_connection_slot(int table_size);
 /**
  * @brief
  * 	char_in_set - is the char c in the tokenset
@@ -1460,6 +1461,26 @@ get_my_index()
 	}
 
 	return my_index;
+}
+
+int 
+get_svr_index(int port)
+{
+	static int svr_index = -1;
+	int i;
+
+	if (svr_index == -1) {
+		if (pbs_conf.pbs_current_servers > 1) {
+			/* find my index */
+			for(i = 0; i < pbs_conf.pbs_current_servers; i++) {
+				if (port == pbs_conf.psi[i]->port)
+					svr_index = i;
+			}
+		} else 
+			return 0;
+	}
+
+	return svr_index;
 }
 
 long long 

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -599,7 +599,7 @@ static struct specials addspecial[] = {
 
 char	*log_file = NULL;
 char	*path_log;
-
+int conn_slot = -1;
 
 char			*ret_string;
 int			ret_size;


### PR DESCRIPTION
Describe Bug or Feature
	•	The current pbs_mom would always connect to default pbs_server(port 15001).
	•	This default configuration won't support for multi-server setup with non-default ports.
	•	To avoid oversubscribing the same service, now pbs_mom would connect to random service(using the get_svr_shard_connection() api for that)

Describe Your Changes
	•	Added new api named get_server_stream() to get the stream to connect the random server, this api would initialize the connection table to multiple-servers.
	•	Modified the existing api get_svr_shard_connection() to use rpp_open() instead of internal_tcp_connect() using the respective function pointer “internal_connect()”
	•	JOB updates would be sent to respective using the same get_server_stream() with jobid parameter as hint to find its server.
	•	Added another API set_server_stream(), that helps to update the connection table to preserve the new incoming connection from the new stream descriptor to the server index appropriately. 

Test Logs:

Tested the modified changes in a multi-server connection. Submitted a job and it ran successfully. 
Logs: 
[Job_Submission_test.txt](https://github.com/subhasisb/pbspro/files/3834226/Job_Submission_test.txt)

