### PR TITLE
fix for MoM connection to another server, if first server goes down

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -135,9 +135,9 @@ extern int * __pbs_tcperrno_location(void);
 
 extern char pbs_current_group[];
 
-enum from {
-	sched,
-	mom
+enum CONN_ORIGIN {
+	SCHED,
+	MOM
 };
 
 
@@ -413,7 +413,7 @@ extern int DIS_wflush(int sock, int rpp);
 extern int engage_external_authentication(int out, int auth_type, int fromsvr, char *ebuf, int ebufsz);
 extern char *PBSD_modify_resv(int connect, char *resv_id,
 	struct attropl *attrib, char *extend);
-extern int initialise_connection_slot(int table_size, enum from client);
+extern int initialise_connection_slot(int table_size, enum CONN_ORIGIN client);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -135,6 +135,12 @@ extern int * __pbs_tcperrno_location(void);
 
 extern char pbs_current_group[];
 
+enum from {
+	sched,
+	mom
+};
+
+
 #define NCONNECTS 50
 
 #define SHARD_CONN_STATE_DOWN 			 0
@@ -407,7 +413,7 @@ extern int DIS_wflush(int sock, int rpp);
 extern int engage_external_authentication(int out, int auth_type, int fromsvr, char *ebuf, int ebufsz);
 extern char *PBSD_modify_resv(int connect, char *resv_id,
 	struct attropl *attrib, char *extend);
-extern int initialise_connection_slot(int table_size);
+extern int initialise_connection_slot(int table_size, enum from client);
 #ifdef	__cplusplus
 }
 #endif

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -720,12 +720,12 @@ tryagain:
 				connection[channel].ch_socket = sd;
 			} else if (connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_CONNECTED) {
 				DBG_TRACE_SHARD((stderr, "already connected!\n"))
+				return  connection[channel].ch_shards[srv_index]->sd;
 			}
 		} else {
 			if ( connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_CONNECTED)
 				return  connection[channel].ch_shards[srv_index]->sd;
 			else {
-				connection[channel].conn_exists = 0;
 				goto tryagain;
 			}
 		}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -113,7 +113,7 @@ struct {
 	{ND_Force_Exclhost,   VNS_FORCE_EXCLHOST}
 };
 
-int initialise_connection_slot(int table_size);
+int initialise_connection_slot(int table_size, enum from client);
 /**
  * @brief
  * 	char_in_set - is the char c in the tokenset
@@ -1560,7 +1560,7 @@ set_nodelay(int fd)
 }
 
 int
-initialise_connection_slot(int table_size)
+initialise_connection_slot(int table_size, enum from client)
 {
 	int i;
 	int j;
@@ -1576,7 +1576,9 @@ initialise_connection_slot(int table_size)
 				connection[i].ch_secondary_socket = -1;
 				connection[i].ch_errtxt = NULL;
 				connection[i].shard_context = -1;
-				connection[i].conn_exists = 1;
+				if (client == sched)
+					connection[i].conn_exists = 1;
+				connection[i].conn_exists = 0;
 
 				if (get_max_servers() > 1) {
 					if (connection[i].ch_shards == NULL) {

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -113,7 +113,7 @@ struct {
 	{ND_Force_Exclhost,   VNS_FORCE_EXCLHOST}
 };
 
-int initialise_connection_slot(int table_size, enum from client);
+int initialise_connection_slot(int table_size, enum CONN_ORIGIN client);
 /**
  * @brief
  * 	char_in_set - is the char c in the tokenset
@@ -1560,7 +1560,7 @@ set_nodelay(int fd)
 }
 
 int
-initialise_connection_slot(int table_size, enum from client)
+initialise_connection_slot(int table_size, enum CONN_ORIGIN client)
 {
 	int i;
 	int j;
@@ -1576,9 +1576,10 @@ initialise_connection_slot(int table_size, enum from client)
 				connection[i].ch_secondary_socket = -1;
 				connection[i].ch_errtxt = NULL;
 				connection[i].shard_context = -1;
-				if (client == sched)
+				if (client == SCHED)
 					connection[i].conn_exists = 1;
-				connection[i].conn_exists = 0;
+				else 
+					connection[i].conn_exists = 0;
 
 				if (get_max_servers() > 1) {
 					if (connection[i].ch_shards == NULL) {

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1932,7 +1932,7 @@ get_server_stream(char *svr, unsigned int port, char *jobid)
 	int	stream = -1;
 	if (pbs_conf.pbs_max_servers > 1) {				
 		if (conn_slot == -1) {
-			conn_slot = initialise_connection_slot(NCONNECTS);
+			conn_slot = initialise_connection_slot(NCONNECTS, mom);
 			if (conn_slot == -1) {
 				log_err(-1, __func__, "connection table initialization failed");
 				return 1;

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1932,7 +1932,7 @@ get_server_stream(char *svr, unsigned int port, char *jobid)
 	int	stream = -1;
 	if (pbs_conf.pbs_max_servers > 1) {				
 		if (conn_slot == -1) {
-			conn_slot = initialise_connection_slot(NCONNECTS, mom);
+			conn_slot = initialise_connection_slot(NCONNECTS, MOM);
 			if (conn_slot == -1) {
 				log_err(-1, __func__, "connection table initialization failed");
 				return 1;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8056,7 +8056,6 @@ net_restore_handler(void *data)
 	mom_net_up = 1;
 	mom_net_up_time = time(0);
 	log_tppmsg(LOG_INFO, msg_daemonname, "net restore handler called");
-	send_restart();
 }
 
 /*

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1350,7 +1350,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	connector = initialise_connection_slot(NCONNECTS, sched);
+	connector = initialise_connection_slot(NCONNECTS, SCHED);
 	if (connector == -1) {
 		log_err(-1, __func__, "connection table initialization failed");
 		die(0);

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1350,7 +1350,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	connector = initialise_connection_slot(NCONNECTS);
+	connector = initialise_connection_slot(NCONNECTS, sched);
 	if (connector == -1) {
 		log_err(-1, __func__, "connection table initialization failed");
 		die(0);


### PR DESCRIPTION
* Fixes the issue related to initial connection failure for node updates. (Intermitted issues) 
* Fix for making the MoM to send hellosvr, if the first connection goes down.
* Modified the get_svr_shard_connection() API for below 2 purposes. 
      1) If the Mom to server connection not exists, it connects via rpp_open and returns stream descriptor.
      2)If the connection already exists, it returns the already connected stream descriptor. 