### PR TITLE
Server/Sched should not crash due to misconfiguration of MultiServer...

### DIFF
--- a/src/lib/Libifl/pbsD_defschreply.c
+++ b/src/lib/Libifl/pbsD_defschreply.c
@@ -91,6 +91,13 @@ pbs_defschreply(int c, int cmd, char *id, int err, char *txt, char *extend)
 	if (pbs_client_thread_lock_connection(c) != 0)
 		return pbs_errno;
 
+	set_new_shard_context(c);
+	sock = get_svr_shard_connection(c, PBS_BATCH_DefSchReply, id);
+	if (sock == -1) {
+		return (pbs_errno = PBSE_NOSERVER);
+	}
+
+
 	/* setup DIS support routines for following DIS calls */
 
 	DIS_tcp_setup(sock);

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1028,6 +1028,10 @@ main(int argc, char **argv)
 
 	if (get_max_servers() > 1) {
 		char buf[PBS_MAXHOSTNAME+8];
+		if (get_my_index() == -1) {
+			fprintf(stderr, "Wrong Multi Server configuration. Please start server after correcting /etc/pbs.conf\n");
+			return 1;
+		}
 
 		sprintf(buf, "%s_%d", daemonname, pbs_conf.batch_service_port);
 		strcpy(daemonname, buf);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
The changes include the bug fixes for the following.
1. Server/Scheduler should not crash if there is any misconfiguration by the Admin. For example if 4 servers are configured but unknowingly if 5 servers are started, 5th server should not come up and throw an appropriate error message on the console. If we cannot fix this it might lead to a crash of Server/Scheduler.
2.  In MultiServer environment pbs_defschreply is not working and sometimes(mostly in qrun case) can lead to a sched crash. This is because pbs_defschreply IFL is not modified to work with MultiServer.

Code changes are made to resolve the above issues.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
