### PR TITLE
Scheduler performance improvement by reducing sched attributes update…

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -273,7 +273,7 @@ extern int			sched_save_db(pbs_sched *, int mode);
 extern enum failover_state	are_we_primary(void);
 extern int			have_socket_licensed_nodes(void);
 extern void			unlicense_socket_licensed_nodes(void);
-extern void			set_sched_default(pbs_sched *, int unset_flag);
+extern void			set_sched_default(pbs_sched *);
 extern pbs_sched *		find_scheduler(char *sched_name);
 extern pbs_sched *		find_scheduler_by_partition(char *partition);
 void				copy_sched_misc_not_in_db(pbs_sched *target, pbs_sched *src);

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -225,6 +225,8 @@ int scheduler_simulation_task(int pbs_sd, int debug);
 
 int update_svr_schedobj(int connector, int cmd, int alarm_time);
 
+int validate_sched_attrs(int connector);
+
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -118,6 +118,7 @@ struct		connect_handle connection[NCONNECTS];
 int		connector = -1;
 int		server_sock;
 int		second_sd = -1;
+int		update_svr = 1;
 fd_set		master_fdset;
 
 #define		START_CLIENTS	2	/* minimum number of clients */
@@ -1456,10 +1457,13 @@ main(int argc, char *argv[])
 						log_buffer);
 				} else {
 					if (connector >= 0) {
-						/* update sched object attributes on server */
-						if (update_svr_schedobj(connector, cmd, alarm_time) == 0) {
-							close_server_conns();
-							break;
+						if (update_svr) {
+							/* update sched object attributes on server */
+							if (update_svr_schedobj(connector, cmd, alarm_time) == 0) {
+								close_server_conns();
+								break;
+							}
+							update_svr = 0;
 						}
 
 						if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -649,7 +649,7 @@ pbsd_init(int type)
 		dflt_scheduler = recov_sched_from_db(NULL, "default", 1);
 		if (!dflt_scheduler) {
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
-			set_sched_default(dflt_scheduler, 0);
+			set_sched_default(dflt_scheduler);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 		}
 		pbs_db_end_trx(conn, PBS_DB_COMMIT);

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1776,7 +1776,7 @@ mgr_sched_set(struct batch_request *preq)
 		pbs_db_end_trx(conn, PBS_DB_ROLLBACK);
 	}
 	else {
-		set_sched_default(psched, 0);
+		set_sched_default(psched);
 		(void)sched_save_db(psched, SVR_SAVE_FULL);
 		if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0) {
 			req_reject(PBSE_SYSTEM, 0, preq);
@@ -1859,7 +1859,7 @@ mgr_sched_unset(struct batch_request *preq)
 	else {
 
 		/* save the attributes to disk */
-		set_sched_default(psched, 1);
+		set_sched_default(psched);
 		(void)sched_save_db(psched, SVR_SAVE_FULL);
 		if (pbs_db_end_trx(conn, PBS_DB_COMMIT) != 0) {
 			req_reject(PBSE_SYSTEM, 0, preq);
@@ -3482,7 +3482,7 @@ mgr_sched_create(struct batch_request *preq)
 	} else {
 
 		/* save the attributes to disk */
-		set_sched_default(psched, 0);
+		set_sched_default(psched);
 		(void) sched_save_db(psched, SVR_SAVE_FULL);
 		snprintf(log_buffer, LOG_BUF_SIZE, msg_manager, msg_man_set,
 				preq->rq_user, preq->rq_host);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -279,7 +279,7 @@ find_assoc_sched_pque(pbs_queue *pq, pbs_sched **target_sched)
 		dflt_scheduler = *target_sched = recov_sched_from_db(NULL, "default", 0);
 		if (!dflt_scheduler) {
 			dflt_scheduler = sched_alloc(PBS_DFLT_SCHED_NAME, 1);
-			set_sched_default(dflt_scheduler, 0);
+			set_sched_default(dflt_scheduler);
 			(void)sched_save_db(dflt_scheduler, SVR_SAVE_NEW);
 			*target_sched = dflt_scheduler;
 		}
@@ -714,7 +714,8 @@ recov_sched_from_db(char *partition, char *sched_name, int lock)
 		snprintf(dbsched.partition_name, sizeof(dbsched.partition_name), "%%%s%%", partition);
 		ps = find_scheduler_by_partition(partition);
 	} else if (sched_name != NULL) {
-		snprintf(dbsched.sched_name, sizeof(dbsched.sched_name), "%s", sched_name);
+		strncpy(dbsched.sched_name, sched_name, sizeof(dbsched.sched_name));
+		dbsched.sched_name[sizeof(dbsched.sched_name) - 1] = '\0';
 		ps = find_scheduler(dbsched.sched_name);
 	}
 

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -427,7 +427,7 @@ poke_scheduler(attribute *pattr, void *pobj, int actmode)
  *
   */
 void
-set_sched_default(pbs_sched *psched, int unset_flag)
+set_sched_default(pbs_sched *psched)
 {
 	char *temp;
 	char dir_path[MAXPATHLEN +1] = {0};
@@ -439,7 +439,7 @@ set_sched_default(pbs_sched *psched, int unset_flag)
 		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_cycle_len]), &sched_attr_def[(int) SCHED_ATR_sched_cycle_len],
 			TOSTR(PBS_SCHED_CYCLE_LEN_DEFAULT));
 	}
-	if (!unset_flag && (psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
+	if ((psched->sch_attr[(int) SCHED_ATR_schediteration].at_flags & ATR_VFLAG_SET) == 0) {
 		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_schediteration]), &sched_attr_def[(int) SCHED_ATR_schediteration],
 			TOSTR(PBS_SCHEDULE_CYCLE));
 	}


### PR DESCRIPTION
…s to Server ...

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
As of today Scheduler updates attributes like sched_host, sched_port etc. to Server during every scheduling cycle even though the frequency of them getting changed is very little. Instead if we can only send these attributes only once to Server we can improve the Scheduler's performance.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

- Make sure that we update sched_host, sched_port etc. from Scheduler to Server as soon as Scheduler comes up. 
- Server can also change these variables at any point in time which should override the values of the above variables without fail. We should still make sure that we will not break this requirement while we do this changes.
- Server sends SCH_ATTRS_CONFIGURE whenever any of the Scheduler's attributes change during which time update_svr_schedobj() gets called. The problem with this function is 1) it updates the attributes like sched_host, sched_port etc to Server/s and also 2) validates the current scheduler attributes with these ones and overrides them. Ideally we should separate this two functionalities and in this case we should only do 2).
Code changes are made accordingly to re-factor this code.
- After these changes if someone unsets scheduling of  a Scheduler object then Server kick off scheduling cycles continuously(which is what our PTL does always). Couple of test cases like test_by_queue and test_mom_hook started failing due to this. Added code changes to make sure that scheduling cycles will not be kicked off continuously even if someone unsets scheduling.
- Fixed some memory leaks
- Replaced sprintf with strncpy in recov_sched_from_db for better performance.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
