### PR TITLE
Creating shard lib to decouple “Sharding Algo” from core.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Libraries
 *.lib
+*.libs
 *.a
 *.la
 *.lo

--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,7 @@ AC_CONFIG_FILES([
 	src/lib/Libsite/Makefile
 	src/lib/Libtpp/Makefile
 	src/lib/Libutil/Makefile
+	src/lib/Libshard/Makefile
 	src/lib/Makefile
 	src/modules/Makefile
 	src/modules/python/Makefile

--- a/pbspro.spec
+++ b/pbspro.spec
@@ -293,6 +293,9 @@ cd build
 %install
 cd build
 %make_install
+%if 0%{?rhel} >= 7
+export QA_RPATHS=$[ 0x0002 ]
+%endif
 
 %post %{pbs_server}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6

--- a/pbspro.spec.in
+++ b/pbspro.spec.in
@@ -293,6 +293,9 @@ cd build
 %install
 cd build
 %make_install
+%if 0%{?rhel} >= 7
+export QA_RPATHS=$[ 0x0002 ]
+%endif
 
 %post %{pbs_server}
 # do not run pbs_postinstall when the CLE is greater than or equal to 6

--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -90,6 +90,7 @@ common_libs = \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	-lm

--- a/src/iff/Makefile.am
+++ b/src/iff/Makefile.am
@@ -46,7 +46,8 @@ pbs_iff_LDADD = \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
 	-lpthread \
 	@socket_lib@ \
-	-lm
+	-lm \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_iff_SOURCES = iff2.c
 

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -41,7 +41,8 @@ include_HEADERS = \
 	pbs_ifl.h \
 	rm.h \
 	tm_.h \
-	tm.h
+	tm.h \
+	libshard.h
 
 noinst_HEADERS = \
 	acct.h \

--- a/src/include/libshard.h
+++ b/src/include/libshard.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 1994-2018 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * PBS Pro is free software. You can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * For a copy of the commercial license terms and conditions,
+ * go to: (http://www.pbspro.com/UserArea/agreement.html)
+ * or contact the Altair Legal Department.
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+ * trademark licensing policies.
+ *
+ */
+
+#ifndef __LIBSHARD_H
+#define __LIBSHARD_H
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+extern int shard_get_server_instance(int pbs_max_servers, char *shard_hint, int *pbs_server_instances, int *inactive_servers);
+
+#ifdef  __cplusplus
+}
+#endif
+#endif /* __LIBSHARD_H */

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -291,6 +291,7 @@ char * get_mem_info(void);
  */
 void convert_duration_to_str(time_t duration, char* buf, int bufsize);
 
+
 int get_max_servers();
 int get_current_servers();
 int get_my_index();

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -70,6 +70,7 @@
 #include "libsec.h"
 #include "pbs_ecl.h"
 #include "pbs_internal.h"
+#include "libshard.h"
 
 
 extern struct connect_handle connection[NCONNECTS];
@@ -648,32 +649,46 @@ get_svr_shard_connection(int channel, int req_type, void *shard_hint)
 {
 	int srv_index;
 	int sd;
-	int first_index = -1;
+	int i = 0;
+	int inact_srv_index = 0;
 	if (internal_connect == NULL)
 		internal_connect = internal_connect_cli;
+	int num_of_indexes = get_current_servers();
+	int svr_indexes[num_of_indexes+1];
+	int inactive_servers[num_of_indexes+1];
+	
+	for (; i < num_of_indexes; i++)
+		inactive_servers[i] = -1;
+
+	i = 0;
+
+	for(; i < num_of_indexes; i++)
+		svr_indexes[i] = i;
+	svr_indexes[i] = -1;
+
 
 	if (pbs_conf.pbs_max_servers > 1) {
+
 		if (shard_hint || connection[channel].shard_context == -1) {
-			srv_index = get_server_shard(shard_hint);
+			srv_index = shard_get_server_instance(pbs_conf.pbs_max_servers, shard_hint, svr_indexes, inactive_servers);
 			connection[channel].shard_context = srv_index; /* reuse the same server in case of a dialogue */
 		} else {
 			srv_index = connection[channel].shard_context;
 		}
 
 tryagain:
-		if (first_index > -1) {
-			srv_index++;
-			if (srv_index >= get_current_servers()) {
-				srv_index = 0;
-			}
-			if (srv_index == first_index) {
+		
+		if (inact_srv_index) {	
+			if (inact_srv_index == pbs_conf.pbs_max_servers)
+				return -1;
+			srv_index = shard_get_server_instance(pbs_conf.pbs_max_servers, shard_hint, svr_indexes, inactive_servers);
+			if (srv_index == -1) {
 				DBG_TRACE_SHARD((stderr, "No nonfailed server, bailing out\n"))
 				connection[channel].ch_socket = -1;
 				return -1;
 			}
-		} else {
-			first_index = srv_index;
 		}
+
 
 		DBG_TRACE_SHARD((stderr, "Selected server index %d, srv=%s:%d, state=%d, ", srv_index, pbs_conf.psi[srv_index]->name, pbs_conf.psi[srv_index]->port, connection[channel].ch_shards[srv_index]->state))
 
@@ -689,7 +704,7 @@ tryagain:
 
 				connection[channel].shard_context = -1;
 				DBG_TRACE_SHARD((stderr, "Failed!\n"))
-				
+				inactive_servers[inact_srv_index++] = srv_index;
 				goto tryagain;
 
 			} else if (connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_DOWN) {
@@ -708,7 +723,7 @@ tryagain:
 					connection[channel].ch_shards[srv_index]->state_change_time = time(0);
 
 					connection[channel].shard_context = -1;
-
+					inactive_servers[inact_srv_index++] = srv_index;
 					goto tryagain;
 				}
 
@@ -726,6 +741,7 @@ tryagain:
 			if ( connection[channel].ch_shards[srv_index]->state == SHARD_CONN_STATE_CONNECTED)
 				return  connection[channel].ch_shards[srv_index]->sd;
 			else {
+				inactive_servers[inact_srv_index++] = srv_index;
 				goto tryagain;
 			}
 		}

--- a/src/lib/Libpbs/Makefile.am
+++ b/src/lib/Libpbs/Makefile.am
@@ -52,7 +52,9 @@ libpbs_la_LDFLAGS = -version-info 0:0:0
 
 libpbs_la_LIBADD= \
 	-lcrypto \
-	-lpthread
+	-lpthread \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
+	
 
 libpbs_la_SOURCES = \
 	../Libattr/attr_fn_arst.c \

--- a/src/lib/Libshard/Makefile.am
+++ b/src/lib/Libshard/Makefile.am
@@ -36,16 +36,11 @@
 # trademark licensing policies.
 #
 
-SUBDIRS = \
-	Libattr \
-	Libdb \
-	Liblog \
-	Libnet \
-	Libshard \
-	Libpbs \
-	Libpython \
-	Libsite \
-	Libsec \
-	Libtpp \
-	Libutil 
+lib_LTLIBRARIES = libshard.la
 
+libshard_la_CPPFLAGS = -I$(top_srcdir)/src/include
+
+libshard_la_LDFLAGS = -version-info 0:0:0
+
+libshard_la_SOURCES = \
+	shard_functions.c 

--- a/src/lib/Libshard/shard_functions.c
+++ b/src/lib/Libshard/shard_functions.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 1994-2018 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * PBS Pro is free software. You can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * PBS Pro is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * For a copy of the commercial license terms and conditions,
+ * go to: (http://www.pbspro.com/UserArea/agreement.html)
+ * or contact the Altair Legal Department.
+ *
+ * Altair’s dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of PBS Pro and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair’s trademarks, including but not limited to "PBS™",
+ * "PBS Professional®", and "PBS Pro™" and Altair’s logos is subject to Altair's
+ * trademark licensing policies.
+ *
+ */
+
+/**
+ * @file	shard_functions.c
+ *
+ * @brief	Miscellaneous utility routines used by the shard library
+ *
+ *
+ */
+#include <pbs_config.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+
+int shard_get_server_instance(int pbs_max_servers, char *shard_hint, int *pbs_server_instances, int *inactive_servers);
+
+
+int
+shard_get_server_instance(int pbs_max_servers, char *shard_hint, int *pbs_server_instances, int *inactive_servers)
+{
+        int srv_ind = 0;
+        int nshardid = 0;
+        int count = 0;
+        int loop_i = 0;
+        static int seeded = 0;
+        struct timeval tv;
+        unsigned long time_in_micros;
+        int *tmp = NULL;
+
+        if (!pbs_max_servers || !pbs_server_instances || pbs_server_instances[0] == -1)
+                return -1;
+
+        tmp = pbs_server_instances;
+        for(; *tmp != -1; tmp++)
+                count++;
+
+        if (shard_hint) {
+                nshardid = strtoull(shard_hint, NULL, 10);
+                srv_ind = nshardid % pbs_max_servers;
+        } else {
+                if (!seeded) {
+                        gettimeofday(&tv,NULL);
+                        time_in_micros = 1000000 * tv.tv_sec + tv.tv_usec;
+                        srand(time_in_micros); /* seed the random generator */
+                        seeded = 1;
+                }
+                srv_ind = pbs_server_instances[rand() % count];
+        }
+
+ check_again:       
+        if (inactive_servers[loop_i] != -1) {
+                for(; inactive_servers[loop_i] != -1; loop_i++) {
+                        if (srv_ind == inactive_servers[loop_i]) {
+                                srv_ind = pbs_server_instances[(srv_ind + 1) % count]; 
+                                goto check_again;
+                        }
+                }
+                if (loop_i == count)
+                        return -1;
+        }
+        return srv_ind;
+}
+

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -1424,7 +1424,7 @@ get_mem_info(void) {
 	}
 	return buf;
 }
-
+#endif /* malloc_info */
 /* hashing functions, move this to hasing.c later */
 int 
 get_max_servers()
@@ -1443,6 +1443,7 @@ get_conf_servers()
 {
 	return pbs_conf.pbs_current_servers;
 }
+
 
 int 
 get_my_index()
@@ -1615,5 +1616,5 @@ initialise_connection_slot(int table_size, enum CONN_ORIGIN client)
 		return (-1);
 }
 
-#endif /* malloc_info */
+
 #endif /* WIN32 */

--- a/src/resmom/Makefile.am
+++ b/src/resmom/Makefile.am
@@ -62,7 +62,8 @@ pbs_mom_LDADD = \
 	@mom_mach_libs@ \
 	@libz_lib@ \
 	-lssl \
-	-lcrypto
+	-lcrypto \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_mom_SOURCES = \
 	$(top_builddir)/src/lib/Libattr/job_attr_def.c \

--- a/src/scheduler/Makefile.am
+++ b/src/scheduler/Makefile.am
@@ -113,6 +113,7 @@ common_libs = \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libsec/libsec.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	@PYTHON_LDFLAGS@ \
 	@PYTHON_LIBS@ \
 	@libz_lib@ \

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -66,7 +66,8 @@ pbs_server_bin_LDADD = \
 	@PYTHON_LDFLAGS@ \
 	@PYTHON_LIBS@ \
 	-lssl \
-	-lcrypto
+	-lcrypto \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_server_bin_SOURCES = \
 	accounting.c \
@@ -143,7 +144,8 @@ pbs_comm_LDADD = \
 	-lpthread \
 	@libz_lib@ \
 	@socket_lib@ \
-	-lm
+	-lm \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_comm_SOURCES = pbs_comm.c
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -60,7 +60,8 @@ common_libs = \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	-lpthread \
 	@socket_lib@ \
-	-lm
+	-lm \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_sleep_LDFLAGS = -all-static
 pbs_sleep_SOURCES = pbs_sleep.c
@@ -75,6 +76,7 @@ pbs_ds_monitor_LDADD = \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	@database_ldflags@ \
@@ -112,6 +114,7 @@ pbs_python_LDADD = \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	@PYTHON_LDFLAGS@ \
@@ -140,6 +143,7 @@ pbs_tclsh_LDADD = \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
 	$(top_builddir)/src/lib/Libtpp/libtpp.a \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	@libz_lib@ \
@@ -160,6 +164,7 @@ pbs_wish_LDADD = \
 	$(top_builddir)/src/lib/Liblog/liblog.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	@tk_lib@
@@ -181,6 +186,7 @@ printjob_svr_bin_LDADD = \
 	$(top_builddir)/src/lib/Libdb/libdb.a \
 	$(top_builddir)/src/lib/Libpbs/.libs/libpbs.a \
 	$(top_builddir)/src/lib/Libnet/libnet.a \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs \
 	-lpthread \
 	@socket_lib@ \
 	@database_ldflags@ \

--- a/src/unsupported/Makefile.am
+++ b/src/unsupported/Makefile.am
@@ -74,6 +74,7 @@ pbs_rmget_LDADD = \
 	$(top_builddir)/src/lib/Libutil/libutil.a \
 	-lpthread \
 	@libz_lib@ \
-	-lm
+	-lm \
+	-lshard -L$(top_builddir)/src/lib/Libshard/.libs
 
 pbs_rmget_SOURCES = pbs_rmget.c


### PR DESCRIPTION
#### Problem:

The sharing logic was embedded with all the client modules to identify its respective server. Its need to be decoupled, so that the user entities could replace the “sharding logic” dynamically. 


#### Describe Your Change
* Created a shared library named “libshard.so” and dynamically linked to all the requested modules to use the exported functions. 
* Apart from choosing the right server, this library interface would check against the list of given “failed servers” list. If the chosen server is marked as inactive, the logic chooses the “NEXT” available active server. If none remains, returns -1.
Design Doc: https://confluence.prog.altair.com/pages/viewpage.action?pageId=77893046
