### PR TITLE
Mom will initiate the dialogue sequence with server

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -324,3 +324,5 @@ extern int get_fullhostname(char *, char *, int);
 }
 #endif
 #endif
+
+int get_max_servers();

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -325,4 +325,4 @@ extern int get_fullhostname(char *, char *, int);
 #endif
 #endif
 
-int get_max_servers();
+int get_max_servers(void);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -74,6 +74,7 @@
 /*
  ** Set up a debug print macro.
  */
+#define	sys_printf(...)	syslog(LOG_NOTICE, __VA_ARGS__);
 #ifdef	DEBUG
 #define	DBPRT(x)	printf x;
 #else

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -150,8 +150,8 @@ extern int mock_run;
 #ifdef	_PBS_JOB_H
 
 #define COMM_MATURITY_TIME  60 /* time when we consider a pbs_comm connection as mature */
-#define MOM_DELTA_NORMAL	1	/* Normal mode of operation for mom_delta function */
-#define MOM_DELTA_RESET	0		/* Reset the values of mom delta function back to 1 */
+#define MOM_DELTA_NORMAL	1	/* Normal mode of operation for time_delta function */
+#define MOM_DELTA_RESET		0	/* Reset the values of time_delta function back to 1 */
 
 typedef	int	(*pbs_jobfunc_t)(job *);
 typedef	int	(*pbs_jobnode_t)(job *, hnodent *);
@@ -180,7 +180,6 @@ extern int   local_checkpoint(job *, int, struct batch_request *);
 extern int   start_restart(job *, struct batch_request *);
 extern int   local_restart(job *, struct batch_request *);
 extern int   time_delta(int);
-void send_hellosvr_tpp(void);
 
 #ifdef WIN32
 extern void  wait_action(void);
@@ -394,7 +393,7 @@ extern void  scan_for_terminated(void);
 extern int   setwinsize(int);
 extern void  set_termcc(int);
 extern int   conn_qsub(char *host, long port);
-extern void  state_to_server(int);
+extern int  state_to_server(int, int);
 extern int   send_hook_vnl(void *vnl);
 extern int hook_requests_to_server(pbs_list_head *);
 extern void  set_job_toexited(char *);

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -151,7 +151,7 @@ extern int mock_run;
 
 #define COMM_MATURITY_TIME  60 /* time when we consider a pbs_comm connection as mature */
 #define MOM_DELTA_NORMAL	1	/* Normal mode of operation for time_delta function */
-#define MOM_DELTA_RESET		0	/* Reset the values of time_delta function back to 1 */
+#define MOM_DELTA_RESET 	0	/* Reset the values of time_delta function back to 1 */
 
 typedef	int	(*pbs_jobfunc_t)(job *);
 typedef	int	(*pbs_jobnode_t)(job *, hnodent *);

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -150,6 +150,8 @@ extern int mock_run;
 #ifdef	_PBS_JOB_H
 
 #define COMM_MATURITY_TIME  60 /* time when we consider a pbs_comm connection as mature */
+#define MOM_DELTA_NORMAL	1
+#define MOM_DELTA_RESET	0
 
 typedef	int	(*pbs_jobfunc_t)(job *);
 typedef	int	(*pbs_jobnode_t)(job *, hnodent *);
@@ -177,6 +179,8 @@ extern int   start_checkpoint(job *, int, struct batch_request *);
 extern int   local_checkpoint(job *, int, struct batch_request *);
 extern int   start_restart(job *, struct batch_request *);
 extern int   local_restart(job *, struct batch_request *);
+extern int   time_delta(int);
+extern char * get_servername_random(uint *);
 
 #ifdef WIN32
 extern void  wait_action(void);
@@ -208,6 +212,7 @@ extern char *set_shell(job *, struct passwd *);
 extern void  start_exec(job *);
 extern void  send_obit(job *, int);
 extern void  send_restart(void);
+extern void send_hellosvr(int);
 extern void  send_wk_job_idle(char *, int);
 extern int   site_job_setup(job *);
 extern int   site_mom_chkuser(job *);

--- a/src/include/mom_func.h
+++ b/src/include/mom_func.h
@@ -150,8 +150,8 @@ extern int mock_run;
 #ifdef	_PBS_JOB_H
 
 #define COMM_MATURITY_TIME  60 /* time when we consider a pbs_comm connection as mature */
-#define MOM_DELTA_NORMAL	1
-#define MOM_DELTA_RESET	0
+#define MOM_DELTA_NORMAL	1	/* Normal mode of operation for mom_delta function */
+#define MOM_DELTA_RESET	0		/* Reset the values of mom delta function back to 1 */
 
 typedef	int	(*pbs_jobfunc_t)(job *);
 typedef	int	(*pbs_jobnode_t)(job *, hnodent *);
@@ -180,7 +180,7 @@ extern int   local_checkpoint(job *, int, struct batch_request *);
 extern int   start_restart(job *, struct batch_request *);
 extern int   local_restart(job *, struct batch_request *);
 extern int   time_delta(int);
-extern char * get_servername_random(uint *);
+void send_hellosvr_tpp(void);
 
 #ifdef WIN32
 extern void  wait_action(void);
@@ -211,7 +211,6 @@ struct passwd	*check_pwd(job *);
 extern char *set_shell(job *, struct passwd *);
 extern void  start_exec(job *);
 extern void  send_obit(job *, int);
-extern void  send_restart(void);
 extern void send_hellosvr(int);
 extern void  send_wk_job_idle(char *, int);
 extern int   site_job_setup(job *);

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -94,29 +94,21 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
  **	Types of Inter Server messages (between Server and Mom).
  */
 #define	IS_NULL			0
-#define	IS_HELLO		1
 #define	IS_CLUSTER_ADDRS	2
 #define IS_UPDATE		3
 #define IS_RESCUSED		4
 #define IS_JOBOBIT		5
 #define IS_BADOBIT		6
-/* #define IS_RESTART		7	 Unused */
+#define IS_REPLYHELLO		7
 #define IS_SHUTDOWN		8
 #define IS_IDLE			9
 #define IS_ACKOBIT		10
-#define IS_GSS_HANDSHAKE	11	/* Deprecated */
-#define IS_CLUSTER_KEY		12	/* Deprecated */
 #define IS_REGISTERMOM		13
 #define IS_UPDATE2		14
-#define IS_HELLO2		15
-#define IS_HOST_TO_VNODE	16
 #define IS_RECVD_VMAP		17
 #define IS_MOM_READY		17	/* alias for IS_RECD_VMAP */
-#define IS_HELLO3		18
 #define IS_DISCARD_JOB		19
-#define IS_HELLO4		20
 #define IS_DISCARD_DONE		21
-#define IS_HPCBP_ATTRIBUTES	22 	/* Deprecated */
 #define	IS_CLUSTER_ADDRS2	23
 #define IS_UPDATE_FROM_HOOK	24 /* request to update vnodes from a hook running on parent mom host */
 #define IS_RESCUSED_FROM_HOOK	25 /* request from child mom for a hook */

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -123,10 +123,6 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define IS_CMD          40
 #define IS_CMD_REPLY    41
 
-/* Bits for IS_HELLO4 contents */
-#define HELLO4_vmap_version	 1
-#define HELLO4_running_jobs	 2
-
 /* return codes for client_to_svr() */
 
 #define PBS_NET_RC_FATAL -1

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -86,8 +86,8 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define	IM_PROTOCOL_VER	6	/* inter-mom protocol version number */
 #define	IM_OLD_PROTOCOL_VER 5	/* inter-mom old protocol version number */
 
-#define	IS_PROTOCOL	4	/* inter-server protocol number */
-#define	IS_PROTOCOL_VER	3	/* inter-server protocol version number */
+#define	IS_PROTOCOL	5	/* inter-server protocol number */
+#define	IS_PROTOCOL_VER	1	/* inter-server protocol version number */
 
 
 /*
@@ -100,7 +100,7 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define IS_RESCUSED		4
 #define IS_JOBOBIT		5
 #define IS_BADOBIT		6
-#define IS_RESTART		7
+/* #define IS_RESTART		7	 Unused */
 #define IS_SHUTDOWN		8
 #define IS_IDLE			9
 #define IS_ACKOBIT		10
@@ -126,6 +126,7 @@ typedef unsigned long pbs_net_t;        /* for holding host addresses */
 #define IS_HOOK_CHECKSUMS		 30 /* mom reports about hooks seen */
 #define IS_HELLO_NO_INVENTORY	31 /* send info about the mom node only */
 #define IS_UPDATE_FROM_HOOK2	32 /* request to update vnodes from a hook running on a parent mom host or an allowed non-parent mom host */
+#define IS_HELLOSVR		33 /* hello send to server from mom to initiate a hello sequence */
 
 #define IS_CMD          40
 #define IS_CMD_REPLY    41

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -129,24 +129,25 @@ typedef struct mominfo mominfo_t;
  */
 
 struct mom_svrinfo {
-	unsigned long msr_state;   /* Mom's state */
-	long	      msr_pcpus;   /* number of physical cpus reported by Mom */
-	long	      msr_acpus;   /* number of avail    cpus reported by Mom */
-	u_Long	      msr_pmem;	   /* amount of physical mem  reported by Mom */
-	int	      msr_numjobs; /* number of jobs on this node */
-	char	     *msr_arch;	    /* reported "arch" */
-	char	     *msr_pbs_ver;  /* mom's reported "pbs_version" */
-	int	      msr_stream;   /* TPP stream to Mom */
-	time_t	      msr_timedown; /* time Mom marked down */
+	unsigned long	msr_state;   /* Mom's state */
+	long		msr_pcpus;   /* number of physical cpus reported by Mom */
+	long		msr_acpus;   /* number of avail    cpus reported by Mom */
+	u_Long		msr_pmem;	   /* amount of physical mem  reported by Mom */
+	int		msr_numjobs; /* number of jobs on this node */
+	char		*msr_arch;	    /* reported "arch" */
+	char		*msr_pbs_ver;  /* mom's reported "pbs_version" */
+	int		msr_stream;   /* TPP stream to Mom */
+	time_t		msr_timedown; /* time Mom marked down */
 	struct work_task *msr_wktask;	/* work task for reque jobs */
 	pbs_list_head	msr_deferred_cmds;	/* links to svr work_task list for TPP replies */
-	unsigned long *msr_addrs;   /* IP addresses of host */
-	int	      msr_numvnds;  /* number of vnodes */
-	int	      msr_numvslots; /* number of slots in msr_children */
-	struct pbsnode **msr_children;  /* array of vnodes supported by Mom */
-	int	      msr_jbinxsz;  /* size of job index array */
-	struct job  **msr_jobindx;  /* index array of jobs on this Mom */
-	long	      msr_vnode_pool;/* the pool of vnodes that belong to this Mom */
+	unsigned long	*msr_addrs;   /* IP addresses of host */
+	int		msr_numvnds;  /* number of vnodes */
+	int		msr_numvslots; /* number of slots in msr_children */
+	struct pbsnode	**msr_children;  /* array of vnodes supported by Mom */
+	int		msr_jbinxsz;  /* size of job index array */
+	struct job	**msr_jobindx;  /* index array of jobs on this Mom */
+	long		msr_vnode_pool;/* the pool of vnodes that belong to this Mom */
+	int		reporting_mom;
 };
 typedef struct mom_svrinfo mom_svrinfo_t;
 
@@ -304,23 +305,23 @@ enum	part_flags { PART_refig, PART_add, PART_rmv };
 #define INUSE_UNRESOLVABLE	 0x08	/* Node not reachable */
 #define	INUSE_JOB	 0x10	/* VP   in used by a job (normal use)	*/
 /* Node all VPs in use by jobs		*/
-#define INUSE_STALE	 0x20	/* Vnode not reported by Mom            */
-#define INUSE_JOBEXCL	 0x40	/* Node is used by one job (exclusive)	*/
-#define	INUSE_BUSY	 0x80	/* Node is busy (high loadave)		*/
-#define INUSE_UNKNOWN	 0x100	/* Node has not been heard from yet	*/
-#define INUSE_INIT	 0x200	/* Node getting vnode map info		*/
-#define INUSE_PROV	 0x400	/* Node is being provisioned		*/
-#define INUSE_WAIT_PROV	 0x800	/* Node is being provisioned		*/
+#define INUSE_STALE	0x20	/* Vnode not reported by Mom            */
+#define INUSE_JOBEXCL	0x40	/* Node is used by one job (exclusive)	*/
+#define	INUSE_BUSY	0x80	/* Node is busy (high loadave)		*/
+#define INUSE_UNKNOWN	0x100	/* Node has not been heard from yet	*/
+#define INUSE_INIT	0x200	/* Node getting vnode map info		*/
+#define INUSE_PROV	0x400	/* Node is being provisioned		*/
+#define INUSE_WAIT_PROV	0x800	/* Node is being provisioned		*/
 /* INUSE_WAIT_PROV is 0x1000 - this should not clash with MOM_STATE_BUSYKB
  * since INUSE_WAIT_PROV is used as part of the node_state and MOM_STATE_BUSYKB
  * is used inside mom for variable internal_state
  */
-#define INUSE_RESVEXCL	0x1000	/* Node is exclusive to a reservation	*/
-#define INUSE_OFFLINE_BY_MOM 0x2000 /* Node is offlined by mom */
-#define INUSE_MARKEDDOWN 0x4000 /* TPP layer marked node down */
+#define INUSE_RESVEXCL		0x1000	/* Node is exclusive to a reservation	*/
+#define INUSE_OFFLINE_BY_MOM	0x2000 /* Node is offlined by mom */
+#define INUSE_MARKEDDOWN	0x4000 /* TPP layer marked node down */
 #define INUSE_NEED_ADDRS	0x8000	/* Needs to be sent IP addrs */
 #define INUSE_MAINTENANCE	0x10000 /* Node has a job in the admin suspended state */
-#define INUSE_SLEEP             0x20000 /* Node is sleeping */
+#define INUSE_SLEEP		0x20000 /* Node is sleeping */
 #define INUSE_NEED_CREDENTIALS	0x40000 /* Needs to be sent credentials */
 
 #define VNODE_AVAILABLE (INUSE_FREE | INUSE_JOB | INUSE_JOBEXCL | \
@@ -489,7 +490,6 @@ extern int add_mom_to_pool(mominfo_t *);
 extern void remove_mom_from_pool(mominfo_t *);
 extern void reset_pool_inventory_mom(mominfo_t *);
 extern vnpool_mom_t *find_vnode_pool(mominfo_t *pmom);
-extern int  send_ip_addrs_to_mom(int);
 extern void mcast_moms();
 #endif
 
@@ -506,9 +506,6 @@ extern mominfo_t	*find_vmapent_byID(void *, const char *);
 extern int		add_vmapent_byID(void *, const char *, void *);
 extern  int		open_momstream(mominfo_t *);
 
-#ifdef	_WORK_TASK_H
-extern  void send_nodes_addr(struct work_task *);
-#endif	/* _WORK_TASK_H */
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -307,7 +307,7 @@ enum	part_flags { PART_refig, PART_add, PART_rmv };
 /* Node all VPs in use by jobs		*/
 #define INUSE_STALE	0x20	/* Vnode not reported by Mom            */
 #define INUSE_JOBEXCL	0x40	/* Node is used by one job (exclusive)	*/
-#define	INUSE_BUSY	0x80	/* Node is busy (high loadave)		*/
+#define INUSE_BUSY	0x80	/* Node is busy (high loadave)		*/
 #define INUSE_UNKNOWN	0x100	/* Node has not been heard from yet	*/
 #define INUSE_INIT	0x200	/* Node getting vnode map info		*/
 #define INUSE_PROV	0x400	/* Node is being provisioned		*/

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -138,8 +138,6 @@ struct mom_svrinfo {
 	char	     *msr_pbs_ver;  /* mom's reported "pbs_version" */
 	int	      msr_stream;   /* TPP stream to Mom */
 	time_t	      msr_timedown; /* time Mom marked down */
-	time_t	      msr_timeinit; /* time Mom marked initializing */
-	time_t        msr_timepinged; /* time Mom was last pinged */
 	struct work_task *msr_wktask;	/* work task for reque jobs */
 	pbs_list_head	msr_deferred_cmds;	/* links to svr work_task list for TPP replies */
 	unsigned long *msr_addrs;   /* IP addresses of host */

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -310,21 +310,20 @@ enum	part_flags { PART_refig, PART_add, PART_rmv };
 #define INUSE_JOBEXCL	 0x40	/* Node is used by one job (exclusive)	*/
 #define	INUSE_BUSY	 0x80	/* Node is busy (high loadave)		*/
 #define INUSE_UNKNOWN	 0x100	/* Node has not been heard from yet	*/
-#define INUSE_NEEDS_HELLO_PING	0x200	/* Fresh hello sequence needs to be initiated */
-#define INUSE_INIT	 0x400	/* Node getting vnode map info		*/
-#define INUSE_PROV	 0x800	/* Node is being provisioned		*/
-#define INUSE_WAIT_PROV	 0x1000	/* Node is being provisioned		*/
+#define INUSE_INIT	 0x200	/* Node getting vnode map info		*/
+#define INUSE_PROV	 0x400	/* Node is being provisioned		*/
+#define INUSE_WAIT_PROV	 0x800	/* Node is being provisioned		*/
 /* INUSE_WAIT_PROV is 0x1000 - this should not clash with MOM_STATE_BUSYKB
  * since INUSE_WAIT_PROV is used as part of the node_state and MOM_STATE_BUSYKB
  * is used inside mom for variable internal_state
  */
-#define INUSE_RESVEXCL	0x2000	/* Node is exclusive to a reservation	*/
-#define INUSE_OFFLINE_BY_MOM 0x4000 /* Node is offlined by mom */
-#define INUSE_MARKEDDOWN 0x8000 /* TPP layer marked node down */
-#define INUSE_NEED_ADDRS	0x10000	/* Needs to be sent IP addrs */
-#define INUSE_MAINTENANCE	0x20000 /* Node has a job in the admin suspended state */
-#define INUSE_SLEEP             0x40000 /* Node is sleeping */
-#define INUSE_NEED_CREDENTIALS	0x80000 /* Needs to be sent credentials */
+#define INUSE_RESVEXCL	0x1000	/* Node is exclusive to a reservation	*/
+#define INUSE_OFFLINE_BY_MOM 0x2000 /* Node is offlined by mom */
+#define INUSE_MARKEDDOWN 0x4000 /* TPP layer marked node down */
+#define INUSE_NEED_ADDRS	0x8000	/* Needs to be sent IP addrs */
+#define INUSE_MAINTENANCE	0x10000 /* Node has a job in the admin suspended state */
+#define INUSE_SLEEP             0x20000 /* Node is sleeping */
+#define INUSE_NEED_CREDENTIALS	0x40000 /* Needs to be sent credentials */
 
 #define VNODE_AVAILABLE (INUSE_FREE | INUSE_JOB | INUSE_JOBEXCL | \
 			 INUSE_RESVEXCL | INUSE_BUSY)
@@ -493,6 +492,7 @@ extern void remove_mom_from_pool(mominfo_t *);
 extern void reset_pool_inventory_mom(mominfo_t *);
 extern vnpool_mom_t *find_vnode_pool(mominfo_t *pmom);
 extern int  send_ip_addrs_to_mom(int);
+extern void mcast_moms();
 #endif
 
 extern  int	   recover_vmap(void);
@@ -506,9 +506,10 @@ extern int		create_vmap(void **);
 extern void		destroy_vmap(void *);
 extern mominfo_t	*find_vmapent_byID(void *, const char *);
 extern int		add_vmapent_byID(void *, const char *, void *);
+extern  int		open_momstream(mominfo_t *);
 
 #ifdef	_WORK_TASK_H
-extern  void ping_nodes(struct work_task *);
+extern  void send_nodes_addr(struct work_task *);
 #endif	/* _WORK_TASK_H */
 #ifdef	__cplusplus
 }

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -147,7 +147,7 @@ struct mom_svrinfo {
 	int		msr_jbinxsz;  /* size of job index array */
 	struct job	**msr_jobindx;  /* index array of jobs on this Mom */
 	long		msr_vnode_pool;/* the pool of vnodes that belong to this Mom */
-	int		reporting_mom;
+	int		reporting_mom; /* Tells whether mom is an inventory reporting mom */
 };
 typedef struct mom_svrinfo mom_svrinfo_t;
 

--- a/src/lib/Libattr/attr_node_func.c
+++ b/src/lib/Libattr/attr_node_func.c
@@ -167,7 +167,7 @@ vnode_state_to_str(int state_bit)
 
 	/* Now clear any internal states */
 	if (state_bit_tmp != 0)
-		state_bit_tmp &= ~(INUSE_DELETED|INUSE_NEEDS_HELLO_PING|INUSE_INIT);
+		state_bit_tmp &= ~(INUSE_DELETED|INUSE_INIT);
 
 	if (state_bit_tmp != 0)
 		return ("");	/* found an unknown state bit set! */

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -54,8 +54,6 @@
 #include "net_connect.h"
 
 
-
-
 /**
  * @brief - Start a standard inter-server message.
  *

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -53,8 +53,8 @@
 #include "tpp.h"
 #include "net_connect.h"
 
-#define	IS_PROTOCOL	4
-#define	IS_PROTOCOL_VER	3
+
+
 
 /**
  * @brief - Start a standard inter-server message.

--- a/src/lib/Libifl/xml_encode_decode.c
+++ b/src/lib/Libifl/xml_encode_decode.c
@@ -200,7 +200,6 @@ decode_argument(char *encoded_arg, char *original_arg)
 #ifdef WIN32
 	int	quotes_flag = 0;
 #endif
-	DBPRT(("%s: encoded arg= %s\n", __func__, encoded_arg))
 
 #ifdef	WIN32
 	/*
@@ -260,7 +259,6 @@ decode_argument(char *encoded_arg, char *original_arg)
 #endif	/* WIN32 */
 
 	original_arg[k] = '\0';
-	DBPRT(("%s: decoded_arg= %s\n", __func__, original_arg))
 	return k;
 }
 

--- a/src/lib/Libtpp/tpp_util.c
+++ b/src/lib/Libtpp/tpp_util.c
@@ -181,8 +181,7 @@ log_tppmsg(int level, const char *objname, char *mess)
 		snprintf(id, sizeof(id), "%s(Thread %d)", (objname != NULL) ? objname : msg_daemonname, thrd_index);
 
 	log_event(etype, PBS_EVENTCLASS_TPP, level, id, mess);
-	DBPRT((mess));
-	DBPRT(("\n"));
+	DBPRT(("%s\n", mess));
 }
 
 /**

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2159,6 +2159,12 @@ crc_file(char *filepath)
 #endif
 }
 
+/**
+ * @brief
+ * 	Return the maximum number of servers possible in the cluster
+ *
+ * @return int
+ */
 int 
 get_max_servers(void)
 {

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2158,3 +2158,9 @@ crc_file(char *filepath)
 	return (crc(buf, sb.st_size));
 #endif
 }
+
+int 
+get_max_servers()
+{
+	return 1;
+}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2160,7 +2160,7 @@ crc_file(char *filepath)
 }
 
 int 
-get_max_servers()
+get_max_servers(void)
 {
 	return 1;
 }

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1986,7 +1986,11 @@ send_hellosvr(int stream)
 	DBPRT(("Sending hellosvr"))
 
 	if (stream < 0) {
-		svr = get_servername_random(&port);
+		if ((svr = get_servername_random(&port)) == NULL) {
+			log_err(errno, msg_daemonname, "get_servername_random() failed");
+			return;
+		}
+
 		stream = tpp_open(svr, port);
 		if (stream < 0) {
 			sprintf(log_buffer, "tpp_open(%s, %d) failed", svr, port);

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1979,8 +1979,8 @@ get_servername_random(unsigned int *port)
 void
 send_hellosvr(int stream)
 {
-	int rc = 0;
-	char	       *svr = NULL;
+	int		rc = 0;
+	char		*svr = NULL;
 	unsigned int	port = default_server_port;
 
 	DBPRT(("Sending hellosvr"))
@@ -1988,24 +1988,15 @@ send_hellosvr(int stream)
 	if (stream < 0) {
 		svr = get_servername_random(&port);
 		stream = tpp_open(svr, port);
+		if (stream < 0) {
+			sprintf(log_buffer, "tpp_open(%s, %d) failed", svr, port);
+			log_err(errno, msg_daemonname, log_buffer);
+			return;
+		}
 	}
 
-	if (stream < 0) {
-		sprintf(log_buffer, "tpp_open(%s, %d) failed", svr, port);
-		log_err(errno, msg_daemonname, log_buffer);
-		return;
-	}
-
-	
-	if (stream < 0) {
-		sprintf(log_buffer, "invalid stream");
-		log_err(errno, msg_daemonname, log_buffer);
-		return;
-	}
-
-	if ((rc = is_compose(stream, IS_HELLOSVR)) != DIS_SUCCESS) {
+	if ((rc = is_compose(stream, IS_HELLOSVR)) != DIS_SUCCESS)
 		goto err;
-	}
 
 	if ((rc = diswui(stream, pbs_mom_port)) != DIS_SUCCESS)
 		goto err;

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8073,7 +8073,7 @@ badguy:
 /*
  * @brief
  *	Function called by the Libtpp layer when the network connection to
- *	the pbs_comm router is restored. In this implementation for the mom.
+ *	the pbs_comm router is restored. This is the implementation for mom.
  *
  * @param[in] data - currently unused
  *

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -272,6 +272,7 @@ unsigned int	pbs_rm_port;
 pbs_list_head	mom_polljobs;	/* jobs that must have resource limits polled */
 pbs_list_head	mom_deadjobs;	/* jobs that need to purged, see chk_del_job */
 int		server_stream = -1;
+int		waiting_hello_resp = 0;
 pbs_list_head	svr_newjobs;	/* jobs being sent to MOM */
 pbs_list_head	svr_alljobs;	/* all jobs under MOM's control */
 time_t		time_last_sample = 0;
@@ -8137,6 +8138,46 @@ net_down_handler(void *data)
 	mom_net_up_time = 0;
 }
 
+
+/**
+ * @brief
+ *      This function returns the time delta
+ * 	after which mom should send the next hello.
+ * 	Tries for short bursts followed by longer intervals.
+ * @param[in] mode -	reset mode is to bring it back to bursting mode
+ * 
+ * @return int
+ * @retval >0 : time mom should wait before sending the next hello
+ * @retval 0 : only in case of reset mode.
+ */
+int
+time_delta(int mode)
+{
+	static int delta = 1;
+	static int cnt = 1;
+	int max_delta_mask = 0x3F;
+
+	DBPRT(("time_delta: mode: %d, delta: %d, cnt: %d", mode, delta, cnt))
+
+	if (mode == MOM_DELTA_RESET) {
+		delta = 1;
+		cnt = 1;
+		return 0;
+	}
+
+	if (cnt == 0) {
+		if (delta & ~max_delta_mask) {
+			return delta;
+		}
+		delta <<= 1;
+		cnt = delta * 2;
+	} else {
+		cnt--;
+	}
+
+	return delta;
+}
+
 #ifdef	WIN32
 /**
  * @brief
@@ -8164,6 +8205,7 @@ main(int argc, char *argv[])
 	time_t				time_state_update = 0;
 	int					tppfd; /* fd for rm and im comm */
 	double				myla;
+	time_t				time_last_hello = 0;
 	job					*nxpjob;
 	job					*pjob;
 	extern time_t		wait_time;
@@ -9646,9 +9688,16 @@ main(int argc, char *argv[])
 		}
 #endif
 
+		time_now = time(NULL);
+		if (server_stream == -1) {
+			if (time_now > time_last_hello) {
+				time_last_hello = time_now + time_delta(MOM_DELTA_NORMAL);
+				send_restart();
+			}
+		}
+
 		wait_time = default_next_task();
 		end_proc();
-		time_now = time(NULL);
 
 		dorestrict_user();
 

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -754,6 +754,8 @@ is_request(int stream, int version)
 		return;
 	}
 
+	/* Server can reach out to mom with requests even before mom sending a hello exchange.
+	   This is one such occassion. So trigger hello exchange now */
 	if (server_stream == -1)
 		send_hellosvr(stream);
 
@@ -806,7 +808,7 @@ is_request(int stream, int version)
 			}
 
 			if (waiting_hello_resp) {
-				(void) time_delta(MOM_DELTA_RESET);
+				time_delta(MOM_DELTA_RESET);
 				waiting_hello_resp = 0;
 				/* fall into IS_HELLO */
 			} else {

--- a/src/resmom/mom_server.c
+++ b/src/resmom/mom_server.c
@@ -130,7 +130,6 @@ extern void	mom_vnlp_report(vnl_t *vnl, char *header);
 extern	char	*path_hooks;
 extern	unsigned long	hooks_rescdef_checksum;
 extern	int	report_hook_checksums;
-extern	int waiting_hello_resp;
 
 /*
  * Tree search generalized from Knuth (6.2.2) Algorithm T just like
@@ -285,12 +284,15 @@ free_vnodemap(void)
  *	reply to server
  *
  * @param[in] stream - connection stream
+ * @param[in] combine_msg - combine message in the caller
  *
- * @return Void
+ * @return int
+ * @retval	0: success
+ * @retval	!0: error code
  *
  */
-static void
-reply_hello4(int stream)
+static int
+registermom(int stream, int combine_msg)
 {
 	int  count = 0;
 	int  hello4_opts = 0;
@@ -316,20 +318,17 @@ reply_hello4(int stream)
 	/* Please note,  the options MUST be sent in the order  */
 	/* that they are defined, least significant bit to most */
 
-	ret = is_compose(stream, IS_HELLO4);
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswui(stream, hello4_opts);
-	if (ret != DIS_SUCCESS)
+	if (!combine_msg)
+		if ((ret = is_compose(stream, IS_REGISTERMOM)) != DIS_SUCCESS)
+			goto err;
+	if ((ret = diswui(stream, hello4_opts)) != DIS_SUCCESS)
 		goto err;
 
 	/* Send vmap version (when that is ready post 8.0.x */
 	if (hello4_opts & HELLO4_vmap_version) {
-		ret = diswul(stream, mominfo_time.mit_time);
-		if (ret != DIS_SUCCESS)
+		if ((ret = diswul(stream, mominfo_time.mit_time)) != DIS_SUCCESS)
 			goto err;
-		ret = diswsi(stream, mominfo_time.mit_gen);
-		if (ret != DIS_SUCCESS)
+		if ((ret = diswsi(stream, mominfo_time.mit_gen)) != DIS_SUCCESS)
 			goto err;
 	}
 
@@ -348,18 +347,17 @@ reply_hello4(int stream)
 		 *   string  - pset value if set, otherwise null string
 		 */
 
-		ret = diswui(stream, count);
+		if ((ret = diswui(stream, count)) != DIS_SUCCESS)
+			goto err;
 		for (pjob = (job *)GET_NEXT(svr_alljobs);
 			pjob && (count > 0);
 			pjob = (job *)GET_NEXT(pjob->ji_alljobs)) {
 
 			--count;
 
-			ret = diswst(stream, pjob->ji_qs.ji_jobid);
-			if (ret != DIS_SUCCESS)
+			if ((ret = diswst(stream, pjob->ji_qs.ji_jobid)) != DIS_SUCCESS)
 				goto err;
-			ret = diswsi(stream, pjob->ji_qs.ji_substate);
-			if (ret != DIS_SUCCESS)
+			if ((ret = diswsi(stream, pjob->ji_qs.ji_substate)) != DIS_SUCCESS)
 				goto err;
 
 			if (pjob->ji_wattr[(int)JOB_ATR_run_version].at_flags & ATR_VFLAG_SET) {
@@ -370,11 +368,9 @@ reply_hello4(int stream)
 			if (ret != DIS_SUCCESS)
 				goto err;
 			/* send Node Id */
-			ret = diswsi(stream, pjob->ji_nodeid);
-			if (ret != DIS_SUCCESS)
+			if ((ret = diswsi(stream, pjob->ji_nodeid)) != DIS_SUCCESS)
 				goto err;
-			ret = diswst(stream, pjob->ji_wattr[(int)JOB_ATR_exec_vnode].at_val.at_str);
-			if (ret != DIS_SUCCESS)
+			if ((ret = diswst(stream, pjob->ji_wattr[(int)JOB_ATR_exec_vnode].at_val.at_str)) != DIS_SUCCESS)
 				goto err;
 			if (pjob->ji_wattr[(int)JOB_ATR_pset].at_flags & ATR_VFLAG_SET)
 				ret = diswst(stream, pjob->ji_wattr[(int)JOB_ATR_pset].at_val.at_str);
@@ -386,8 +382,9 @@ reply_hello4(int stream)
 
 	}
 
-	dis_flush(stream);
-	return;
+	if (!combine_msg)
+		dis_flush(stream);
+	return 0;
 
 err:
 	sprintf(log_buffer, "%s for %s", dis_emsg[ret], "HELLO");
@@ -397,6 +394,7 @@ err:
 #endif
 		log_err(errno, "send_resc_used", log_buffer);
 	tpp_close(stream);
+	return ret;
 }
 
 /**
@@ -687,6 +685,106 @@ err:
 
 /**
  * @brief
+ *	This function will process the rpp values from the server stream.
+ *
+ * @param[in]	stream - the communication stream
+ * 
+ * @return	int
+ * @retval	0: success
+ * @retval	!0: Error code
+ */
+static int
+process_rpp_values(int stream)
+{
+	int new_retry, new_water;
+	int ret = 0;
+
+	DBPRT(("%s: IS_NULL\n", __func__))
+
+	new_retry = disrsi(stream, &ret);
+	if (ret != DIS_SUCCESS)
+		return ret;
+
+	new_water = disrsi(stream, &ret);
+	if (ret != DIS_SUCCESS)
+		return ret;
+	/*
+	** rpp_retry can be zero, i.e. no retries.
+	*/
+	DBPRT(("rpp_retry: %d: rpp_highwater:%d\n", new_retry, new_water))
+	if (new_retry >= 0 && rpp_retry != new_retry) {
+		sprintf(log_buffer, "rpp_retry changed from %d to %d",
+			rpp_retry, new_retry);
+		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER,
+			LOG_DEBUG, msg_daemonname, log_buffer);
+		rpp_retry = new_retry;
+	}
+	/*
+	** rpp_highwater must be greater than zero.
+	** It is the number of packets allowed to be "on the wire"
+	** at any given time.
+	*/
+	if (new_water > 0 && rpp_highwater != new_water) {
+		sprintf(log_buffer,
+			"rpp_highwater changed from %d to %d",
+			rpp_highwater, new_water);
+		log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER,
+			LOG_DEBUG, msg_daemonname, log_buffer);
+		rpp_highwater = new_water;
+	}
+	return 0;
+}
+
+/**
+ * @brief
+ *	This function will process the cluster addresses from the server stream.
+ *
+ * @param[in]	stream - the communication stream
+ * 
+ * @return	int
+ * @retval	0: success
+ * @retval	!0: Error code
+ */
+static int
+process_cluster_addrs(int stream)
+{
+	u_long	ipaddr;
+	int	i;
+	int 	tot = 0;
+	int	ret = 0;
+	u_long	ipdepth = 0;
+	u_long	counter = 0;
+
+	DBPRT(("%s: IS_CLUSTER_ADDRS2\n", __func__))
+	enable_exechost2 = 1;
+
+	tot = disrui(stream, &ret);
+	if (ret != DIS_SUCCESS)
+		return ret;
+
+	for (i = 0; i < tot; i++) {
+		ipaddr = disrul(stream, &ret);
+		if (ret != DIS_SUCCESS)
+			break;
+		ipdepth = disrul(stream, &ret);
+		if (ret != DIS_SUCCESS)
+			break;
+		counter = ipaddr;
+		while (counter <= ipaddr + ipdepth) {
+			DBPRT(("%s:\t%ld.%ld.%ld.%ld", __func__,
+				(counter & 0xff000000) >> 24,
+				(counter & 0x00ff0000) >> 16,
+				(counter & 0x0000ff00) >> 8,
+				(counter & 0x000000ff)))
+			addrinsert(counter++);
+			DBPRT(("ipdepth: %lu\n", ipdepth))
+		}
+	}
+	return 0;
+}
+
+/**
+ * @brief
  *	This handles input coming from another server over a DIS on tpp stream.
  *	Read the stream to get a Inter-Server request.
  *
@@ -697,34 +795,22 @@ err:
 void
 is_request(int stream, int version)
 {
-	u_long			ipdepth = 0;
-	u_long			counter = 0;
 	int			command = 0;
-	int			i;
 	int			n;
 	int			ret = DIS_SUCCESS;
 	u_long			ipaddr;
-	short			port;
 	char			*jobid = NULL;
 	struct	sockaddr_in	*addr;
 	void			init_addrs();
-	char		 	*hostn;
-	char		 	*vnoden;
-	char		 	*vhost;
-	int			notask;
 	job			*pjob;
-	mominfo_t		*pmom;
-	mominfo_time_t		map_stamp;
-	char			vmapfile[MAXPATHLEN+1];
-	char			vmapfilenew[MAXPATHLEN+1];
 	FILE		 	*filen = 0;
-	int			new_retry, new_water;
 	extern vnl_t		*vnlp;        		/* vnode list */
 	extern vnl_t		*vnlp_from_hook;        /* vnode list updates from hook */
 	int			hktype;
 	unsigned long		hkseq;
 	struct hook_job_action *phjba;
 	struct hook_vnl_action *phvna;
+	int			need_inv;
 	mom_hook_input_t	*phook_input = NULL;
 	mom_hook_output_t	*phook_output = NULL;
 
@@ -744,7 +830,6 @@ is_request(int stream, int version)
 		tpp_close(stream);
 		return;
 	}
-	port = ntohs((unsigned short)addr->sin_port);
 	ipaddr = ntohl(addr->sin_addr.s_addr);
 
 	if (!addrfind(ipaddr)) {
@@ -765,109 +850,45 @@ is_request(int stream, int version)
 
 	switch (command) {
 
-		case IS_NULL:		/* a reply from the server */
-			DBPRT(("%s: IS_NULL\n", __func__))
+		case IS_NULL:
+			if ((ret = process_rpp_values(stream)) != 0)
+				goto err;
+			break;
 
-			/*
-			 ** If the server supports it, values for
-			 ** rpp_retry and rpp_highwater will be sent
-			 ** with pings.
-			 */
-			new_retry = disrsi(stream, &ret);
-			if (ret == DIS_EOD)	/* old server */
-				break;
+		case IS_REPLYHELLO:	/* servers return greeting to IS_HELLOSVR */
+			DBPRT(("%s: IS_REPLYHELLO, state=0x%x stream=%d\n", __func__,
+				internal_state, stream))
+			time_delta(MOM_DELTA_RESET);
+			need_inv = disrsi(stream, &ret);
 			if (ret != DIS_SUCCESS)
 				goto err;
-
-			new_water = disrsi(stream, &ret);
-			if (ret != DIS_SUCCESS)
+			if ((ret = process_rpp_values(stream)) != DIS_SUCCESS)
 				goto err;
-			/*
-			 ** rpp_retry can be zero, i.e. no retries.
-			 */
-			DBPRT(("rpp_retry: %d: rpp_highwater:%d\n", new_retry, new_water))
-			if (new_retry >= 0 && rpp_retry != new_retry) {
-				sprintf(log_buffer, "rpp_retry changed from %d to %d",
-					rpp_retry, new_retry);
-				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER,
-					LOG_DEBUG, msg_daemonname, log_buffer);
-				rpp_retry = new_retry;
-			}
-			/*
-			 ** rpp_highwater must be greater than zero.
-			 ** It is the number of packets allowed to be "on the wire"
-			 ** at any given time.
-			 */
-			if (new_water > 0 && rpp_highwater != new_water) {
-				sprintf(log_buffer,
-					"rpp_highwater changed from %d to %d",
-					rpp_highwater, new_water);
-				log_event(PBSEVENT_ADMIN, PBS_EVENTCLASS_SERVER,
-					LOG_DEBUG, msg_daemonname, log_buffer);
-				rpp_highwater = new_water;
-			}
+			ret = process_cluster_addrs(stream);
+			if (ret != 0 && ret != DIS_EOD)
+				goto err;
 
-			if (waiting_hello_resp) {
-				time_delta(MOM_DELTA_RESET);
-				waiting_hello_resp = 0;
-				/* fall into IS_HELLO */
+			 /* return a IS_REGISTERMOM followed by an UPDATE or UPDATE2 */
+
+			next_sample_time = min_check_poll;
+			if ((ret = is_compose(stream, IS_REGISTERMOM)) != DIS_SUCCESS)
+				goto err;
+			if ((ret = registermom(stream, 1)) != 0)
+				goto err;
+			internal_state_update = UPDATE_MOM_STATE;
+			if (need_inv) {
+				if ((ret = state_to_server(UPDATE_VNODES, 1)) != DIS_SUCCESS)
+					goto err;
+				sprintf(log_buffer, "ReplyHello from server at %s", netaddr(addr));
 			} else {
-				break;
+				if ((ret = state_to_server(UPDATE_MOM_ONLY, 1)) != DIS_SUCCESS)
+					goto err;
+				sprintf(log_buffer, "ReplyHello (no inventory required) from server at %s", netaddr(addr));
 			}
-
-		case IS_HELLO:		/* server wants a return greeting (HELLO) */
-			DBPRT(("%s: IS_HELLO, state=0x%x stream=%d\n", __func__,
-				internal_state, stream))
-			/*
-			 * return a HELLO2 followed by an UPDATE or UPDATE2 which has
-			 *	the number of physical CPUs (int)
-			 *	the number of available CPUs (int)
-			 *	the amount of physical memory in KBs (string)
-			 *	the arch (string)
-			 *	the license type required
-			 * Note, the HELLO2 means the Server is ver 8.0 or higher and
-			 * does "vnodes".
-			 */
-			next_sample_time = min_check_poll;
-			reply_hello4(stream);
-			internal_state_update = UPDATE_MOM_STATE;
-			state_to_server(UPDATE_VNODES);
-			sprintf(log_buffer, "Hello from server at %s", netaddr(addr));
 			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER,  LOG_DEBUG,
-				msg_daemonname, log_buffer);
+					msg_daemonname, log_buffer);
+			dis_flush(server_stream);
 
-			break;
-
-		case IS_HELLO_NO_INVENTORY:
-			DBPRT(("%s: IS_HELLO_NO_INVENTORY, state=0x%x stream=%d\n", __func__,
-				internal_state, stream))
-			next_sample_time = min_check_poll;
-			reply_hello4(stream);
-			internal_state_update = UPDATE_MOM_STATE;
-			state_to_server(UPDATE_MOM_ONLY);
-			sprintf(log_buffer, "Hello (no inventory required) from server at %s", netaddr(addr));
-			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER,  LOG_DEBUG,
-				msg_daemonname, log_buffer);
-			break;
-
-		case IS_CLUSTER_ADDRS:
-			DBPRT(("%s: IS_CLUSTER_ADDRS\n", __func__))
-			enable_exechost2 = 0;
-			for (;;) {
-				ipaddr = disrul(stream, &ret);
-				if (ret != DIS_SUCCESS)
-					break;
-				DBPRT(("%s:\t%ld.%ld.%ld.%ld\n", __func__,
-					(ipaddr & 0xff000000) >> 24,
-					(ipaddr & 0x00ff0000) >> 16,
-					(ipaddr & 0x0000ff00) >> 8,
-					(ipaddr & 0x000000ff)))
-				addrinsert(ipaddr);
-			}
-			if (ret != DIS_EOD)
-				goto err;
-			is_compose(stream, IS_MOM_READY);  /* tell server we're ready */
-			dis_flush(stream);
 			if (send_hook_checksums() != DIS_SUCCESS)
 				goto err;
 			/* send any unacknowledged hook job and vnl action requests */
@@ -886,153 +907,9 @@ is_request(int stream, int version)
 			break;
 
 		case IS_CLUSTER_ADDRS2:
-			DBPRT(("%s: IS_CLUSTER_ADDRS2\n", __func__))
-			enable_exechost2 = 1;
-			for (;;) {
-				ipaddr = disrul(stream, &ret);
-				if (ret != DIS_SUCCESS)
-					break;
-				ipdepth = disrul(stream, &ret);
-				if (ret != DIS_SUCCESS)
-					break;
-				counter = ipaddr;
-				while (counter <= ipaddr + ipdepth) {
-					DBPRT(("%s:\t%ld.%ld.%ld.%ld", __func__,
-						(counter & 0xff000000) >> 24,
-						(counter & 0x00ff0000) >> 16,
-						(counter & 0x0000ff00) >> 8,
-						(counter & 0x000000ff)))
-					addrinsert(counter++);
-					DBPRT((" %lu\n", ipdepth))
-				}
-			}
-			if (ret != DIS_EOD)
+			ret = process_cluster_addrs(stream);
+			if (ret != 0 && ret != DIS_EOD)
 				goto err;
-			is_compose(stream, IS_MOM_READY);  /* tell server we're ready */
-			dis_flush(stream);
-
-			if (send_hook_checksums() != DIS_SUCCESS)
-				goto err;
-			/* send any unacknowledged hook job and vnl action requests */
-			send_hook_job_action(NULL);
-			hook_requests_to_server(&svr_hook_vnl_actions);
-			svr_hook_resend_job_attrs = 1;
-
-			/* send any vnode changes made by */
-			/* exechost_startup hook */
-			mom_vnlp_report(vnlp_from_hook, "VNLP_FROM_HOOK");
-			(void)send_hook_vnl(vnlp_from_hook);
-			/* send_hook_vnl() saves 'vnlp_from_hook' internally, */
-			/* to be freed later when server acks the request. */
-			vnlp_from_hook = NULL;
-			mom_recvd_ip_cluster_addrs = 1;
-			break;
-
-		case IS_HOST_TO_VNODE:
-			DBPRT(("%s: IS_HOST_TO_VNODE\n", __func__))
-			/* receive the host/port/vnodes mapping */
-
-			map_stamp.mit_time = disrul(stream, &ret);
-			if (ret != DIS_SUCCESS)
-				goto err;
-			map_stamp.mit_gen = disrsi(stream, &ret);
-			if (ret != DIS_SUCCESS)
-				goto err;
-			sprintf(log_buffer, "HOST_TO_VNODE map received, ver %lu.%d, prior was %lu.%d", map_stamp.mit_time, map_stamp.mit_gen, mominfo_time.mit_time, mominfo_time.mit_gen);
-			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER,  LOG_DEBUG,
-				msg_daemonname, log_buffer);
-
-			if ((map_stamp.mit_time < mominfo_time.mit_time)    ||
-				((map_stamp.mit_time == mominfo_time.mit_time) &&
-				(map_stamp.mit_gen  <= mominfo_time.mit_gen))) {
-
-				/* same old data again, just ignore */
-
-				break;
-			}
-
-			/* have new mapping, discard old and setup new */
-
-			free_vnodemap();		/* free the old arrays */
-			sprintf(vmapfile,    "%s/%s", mom_home, VNODE_MAP);
-			sprintf(vmapfilenew, "%s/%s.new", mom_home, VNODE_MAP);
-			filen = fopen(vmapfilenew, "w");
-			if (filen == NULL)
-				goto err;
-			fprintf(filen, "%lu.%d\n", map_stamp.mit_time, map_stamp.mit_gen);
-			while (1) {
-				hostn = disrst(stream, &ret);	/* a host name */
-				if (ret == DIS_EOD)
-					break;
-				else if (ret != DIS_SUCCESS) {
-					free_vnodemap();
-					goto err;
-				}
-				port = (short)disrui(stream, &ret);
-				if (ret != DIS_SUCCESS) {
-					free(hostn);
-					free_vnodemap();
-					goto err;
-				}
-				n = disrui(stream, &ret);	/* number of vnodes */
-				if (ret != DIS_SUCCESS) {
-					free(hostn);
-					free_vnodemap();
-					goto err;
-				}
-				/* add mominfo_array entry for the host/mom */
-				pmom = create_mom_entry(hostn, (unsigned int)port);
-				fprintf(filen, "%s %u %d\n", hostn, port, n);
-				if (pmom == NULL) {
-					free(hostn);
-					free_vnodemap();
-					goto err;
-				}
-				free(hostn);
-
-				for (i=0; i<n; ++i) {
-					/* add momvmap entry for each vnode */
-					vnoden = disrst(stream, &ret);
-					if (ret != DIS_SUCCESS) {
-						free_vnodemap();
-						goto err;
-					}
-					vhost  = disrst(stream, &ret);
-					if (ret != DIS_SUCCESS) {
-						free(vnoden);
-						free_vnodemap();
-						goto err;
-					}
-					notask = disrui(stream, &ret);
-					if (ret != DIS_SUCCESS) {
-						free(vnoden);
-						free_vnodemap();
-						goto err;
-					}
-					if (create_mommap_entry(vnoden, vhost, pmom, notask) == NULL) {
-						free(vnoden);
-						free_vnodemap();
-						goto err;
-					}
-					if ((vhost == NULL) || (*vhost == '\0'))
-						fprintf(filen, "\t%s - %d\n", vnoden, notask);
-					else
-						fprintf(filen, "\t%s %s %d\n", vnoden, vhost, notask);
-					free(vnoden);
-				}
-			}
-			fclose(filen);
-			filen = NULL;
-			mominfo_time = map_stamp;
-			(void)rename(vmapfilenew, vmapfile);
-#ifdef WIN32
-			secure_file(vmapfile, "Administrators",
-				READS_MASK|WRITES_MASK|STANDARD_RIGHTS_REQUIRED);
-#endif
-			/* if any of the reads/writes above failed, where we went */
-			/* to "err", the stream to the Server is closed, so we	  */
-			/* still appear down					  */
-
 			break;
 
 		case IS_BADOBIT:
@@ -1374,15 +1251,18 @@ hook_requests_to_server_err:
  * @param[in]	what_to_update - defines what to update
  * 		UPDATE_VNODES - update all the vnodes
  *		UPDATE_MOM_ONLY - update only the info about the mom
+ * @param[in]	combine_msg	- combine message in the caller.
  *
  *	If we have placement set information to send, we use IS_UPDATE2;
  *	otherwise, we fall back to IS_UPDATE.
  *
- * @return Void
+ * @return int
+ * @retval	0: success
+ * @retval	1: failure
  *
  */
-void
-state_to_server(int what_to_update)
+int
+state_to_server(int what_to_update, int combine_msg)
 {
 	int			i, ret;
 	int			use_UPDATE2;
@@ -1391,10 +1271,10 @@ state_to_server(int what_to_update)
 	char			*pv;
 
 	if (internal_state_update == 0)
-		return;
+		return 0;
 
 	if (server_stream < 0)
-		return;
+		return -1;
 
 	if (av_phy_mem == 0)
 		av_phy_mem = strTouL(physmem(0), &pv, 10);
@@ -1412,36 +1292,31 @@ state_to_server(int what_to_update)
 	else
 		use_UPDATE2 = 0;
 
-	if (use_UPDATE2)
-		ret = is_compose(server_stream, IS_UPDATE2);
-	else
-		ret = is_compose(server_stream, IS_UPDATE);
+	if (!combine_msg) {
+		if (use_UPDATE2)
+			ret = is_compose(server_stream, IS_UPDATE2);
+		else
+			ret = is_compose(server_stream, IS_UPDATE);
+	} else {
+		if (use_UPDATE2)
+			ret = diswui(server_stream, IS_UPDATE2);
+		else
+			ret = diswui(server_stream, IS_UPDATE);
+	}
 	if (ret != DIS_SUCCESS)
 		goto err;
 
-	ret = diswui(server_stream, i);		/* node state */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswui(server_stream, i)) != DIS_SUCCESS)		/* node state */
 		goto err;
-	ret = diswui(server_stream, num_pcpus); /* phy cpus */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswui(server_stream, num_pcpus)) != DIS_SUCCESS) /* phy cpus */
 		goto err;
-	ret = diswui(server_stream, num_acpus); /* avail cpus */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswui(server_stream, num_acpus)) != DIS_SUCCESS) /* avail cpus */
 		goto err;
-	ret = diswull(server_stream, av_phy_mem); /* phy mem */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswull(server_stream, av_phy_mem)) != DIS_SUCCESS) /* phy mem */
 		goto err;
-	ret = diswst(server_stream, arch(0));	/* arch type */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswst(server_stream, arch(0))) != DIS_SUCCESS)	/* arch type */
 		goto err;
-	ret = diswui(server_stream, 0); /* license type in Bubo no longer   */
-	/* makes sense as licenses 	    */
-	/* apply to jobs and not nodes.      */
-	/* Passing a dummy 0 to prevent   */
-	/* breakage of protocol.	  */
 
-	if (ret != DIS_SUCCESS)
-		goto err;
 	if (use_UPDATE2) {
 #if	MOM_ALPS
 		/*
@@ -1465,92 +1340,23 @@ state_to_server(int what_to_update)
 		vnlp->vnl_modtime = time(0);
 #endif	/* MOM_ALPS */
 
-		ret = vn_encode_DIS(server_stream, vnlp);	/* vnode list */
-		if (ret != DIS_SUCCESS)
+		if ((ret = vn_encode_DIS(server_stream, vnlp)) != DIS_SUCCESS)	/* vnode list */
 			goto err;
 	}
 
-	ret = diswst(server_stream, PBS_VERSION);	/* pbs_version */
-	if (ret != DIS_SUCCESS)
+	if ((ret = diswst(server_stream, PBS_VERSION)) != DIS_SUCCESS)	/* pbs_version */
 		goto err;
 
-	dis_flush(server_stream);
+	if (!combine_msg)
+		dis_flush(server_stream);
 	internal_state_update = 0;
-	return;
+	return 0;
 
 err:
 	log_err(errno, "state_to_server", (char *)dis_emsg[ret]);
 	tpp_close(server_stream);
 	server_stream = -1;
-}
-
-/**
- * @brief
- * 	register_withserver() - send info about this Mom to the Server.
- *
- * @return Void
- *
- */
-void
-register_with_server(void)
-{
-	int			i, ret;
-	extern const char *dis_emsg[];
-	char			*pv;
-
-	if (server_stream < 0)
-		return;
-
-	if (av_phy_mem == 0)
-		av_phy_mem = strTouL(physmem(0), &pv, 10);
-
-	i = internal_state & MOM_STATE_MASK;
-	if (internal_state & (MOM_STATE_BUSYKB | MOM_STATE_INBYKB))
-		i |= MOM_STATE_BUSY;
-	if (cycle_harvester == 1)
-		i |= MOM_STATE_CONF_HARVEST;
-
-	DBPRT(("updating state 0x%x to server\n", i))
-	ret = is_compose(server_stream, IS_REGISTERMOM);
-	if (ret != DIS_SUCCESS)
-		goto err;
-
-	ret = diswst(server_stream, mom_short_name); /* short host name */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswui(server_stream, pbs_mom_port);   /* mom's port */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswui(server_stream, i);		/* node state */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswsi(server_stream, num_pcpus); /* phy cpus */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswsi(server_stream, num_acpus); /* avail cpus */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswull(server_stream, av_phy_mem); /* phy mem */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswst(server_stream, arch(0));	/* arch type */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	ret = diswui(server_stream, 0); /* license type in Bubo no longer */
-	/* makes sense as licenses apply  */
-	/* to jobs instead of nodes.      */
-	/* Passing a dummy 0 to prevent   */
-	/* breakage of protocol.	  */
-	if (ret != DIS_SUCCESS)
-		goto err;
-	dis_flush(server_stream);
-
-	return;
-
-err:
-	log_err(errno, "register_with_server", (char *)dis_emsg[ret]);
-	tpp_close(server_stream);
-	server_stream = -1;
+	return ret;
 }
 
 /**

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -6079,9 +6079,8 @@ start_exec(job *pjob)
 #endif/* MOM_BGL */
 
 	/* make sure we have an open tpp stream back to the server */
-
 	if (server_stream == -1)
-		send_hellosvr_tpp();
+		send_hellosvr(server_stream);
 
 #if MOM_ALPS
 	/* set ALPS reservation id to -1 to indicate there isn't one yet */

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -6081,7 +6081,7 @@ start_exec(job *pjob)
 	/* make sure we have an open tpp stream back to the server */
 
 	if (server_stream == -1)
-		send_restart();
+		send_hellosvr_tpp();
 
 #if MOM_ALPS
 	/* set ALPS reservation id to -1 to indicate there isn't one yet */

--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -4119,9 +4119,8 @@ start_exec(job *pjob)
 	int			mtfd = -1;
 
 	/* make sure we have an open tpp stream back to the server */
-
 	if (server_stream == -1)
-		send_hellosvr_tpp();
+		send_hellosvr(server_stream);
 
 	/* The following may not be needed for Windows! */
 	if (pjob->ji_mompost) {         /* fail until activity is done */

--- a/src/resmom_win/start_exec.c
+++ b/src/resmom_win/start_exec.c
@@ -4121,7 +4121,7 @@ start_exec(job *pjob)
 	/* make sure we have an open tpp stream back to the server */
 
 	if (server_stream == -1)
-		send_restart();
+		send_hellosvr_tpp();
 
 	/* The following may not be needed for Windows! */
 	if (pjob->ji_mompost) {         /* fail until activity is done */

--- a/src/server/issue_request.c
+++ b/src/server/issue_request.c
@@ -138,7 +138,7 @@ relay_to_mom2(job *pjob, struct batch_request *request,
 	momport = pjob->ji_qs.ji_un.ji_exect.ji_momport;
 
 	pmom = tfind2((unsigned long) momaddr, momport, &ipaddrs);
-	if (!pmom || (((mom_svrinfo_t *) (pmom->mi_data))->msr_state & INUSE_DOWN)) {
+	if (!pmom || ((((mom_svrinfo_t *) (pmom->mi_data))->msr_state & INUSE_DOWN) && open_momstream(pmom) < 0)) {
 		return (PBSE_NORELYMOM);
 	}
 	mom_tasklist_ptr = &(((mom_svrinfo_t *) (pmom->mi_data))->msr_deferred_cmds);

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -377,6 +377,7 @@ create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul)
 	psvrmom->msr_numvnds = 0;
 	psvrmom->msr_numvslots = 1;
 	psvrmom->msr_vnode_pool = 0;
+	psvrmom->reporting_mom = 0;
 	psvrmom->msr_children =
 		(struct pbsnode **)calloc((size_t)(psvrmom->msr_numvslots),
 		sizeof(struct pbsnode *));

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -370,7 +370,6 @@ create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul)
 	psvrmom->msr_stream  = -1;
 	CLEAR_HEAD(psvrmom->msr_deferred_cmds);
 	psvrmom->msr_timedown = (time_t)0;
-	psvrmom->msr_timeinit = (time_t)0;
 	psvrmom->msr_wktask  = 0;
 	psvrmom->msr_addrs   = pul;
 	psvrmom->msr_jbinxsz = 0;
@@ -413,10 +412,6 @@ open_momstream(mominfo_t *pmom)
 	mom_svrinfo_t *psvrmom;
 
 	psvrmom = (mom_svrinfo_t *)pmom->mi_data;
-	if (psvrmom->msr_state & INUSE_NEED_ADDRS)
-		return -1;
-
-	/* take existing stream out of tree */
 	if (psvrmom->msr_stream >= 0) {
 		return -1;
 	}

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -791,8 +791,8 @@ setup_notification()
 {
 	int	i;
 	int	nmom;
-	static	time_t last_sent_tm = 0;
 
+	/* CLUSTERADDR2 is not enabled for multi-server case, hence bailing-out. */
 	if (get_max_servers() > 1)
 		return;
 
@@ -808,9 +808,11 @@ setup_notification()
 	}
 
 	/* send IS_CLUSTERADDR2 to happen in next 2 seconds */
-	if (last_sent_tm < time_now) {
-		last_sent_tm = time_now + 2;
-		set_task(WORK_Timed, last_sent_tm, send_nodes_addr, NULL);
+	static	time_t addr_send_tm = 0;
+	if (addr_send_tm <= time_now) {
+		addr_send_tm = time_now + 2;
+		struct work_task *ptask = set_task(WORK_Timed, addr_send_tm, mcast_moms, NULL);
+		ptask->wt_aux = IS_CLUSTER_ADDRS2;
 	}
 }
 

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -804,7 +804,6 @@ setup_notification()
 		pbsndlist[i]->nd_attr[(int)ND_ATR_state].at_flags |= ATR_VFLAG_MODCACHE;
 		for (nmom = 0; nmom < pbsndlist[i]->nd_nummoms; ++nmom) {
 			((mom_svrinfo_t *)(pbsndlist[i]->nd_moms[nmom]->mi_data))->msr_state |= INUSE_NEED_ADDRS;
-			((mom_svrinfo_t *)(pbsndlist[i]->nd_moms[nmom]->mi_data))->msr_timepinged = 0;
 		}
 	}
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -4416,7 +4416,6 @@ found:
 				Set_All_State_Regardless);
 			set_all_state(pmom, 1, INUSE_DOWN|INUSE_INIT, NULL,
 				Set_ALL_State_All_Down);
-			psvrmom->msr_timeinit = time_now;
 			if ((psvrmom->msr_state & INUSE_MARKEDDOWN) == 0)
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_INFO,
 					pmom->mi_host, "Setting host to Initialize");
@@ -4909,7 +4908,6 @@ found:
 				LOG_NOTICE, pmom->mi_host, node_up);
 			}
 			psvrmom->msr_timedown = 0;
-			psvrmom->msr_timeinit = 0;
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 			if (psvrmom->msr_state & INUSE_NEED_CREDENTIALS) {

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -51,7 +51,6 @@
  * 	node_down_requeue()
  * 	post_discard_job()
  * 	momptr_down()
- * 	ping_a_mom()
  * 	set_vnode_state()
  * 	vnode_available()
  * 	vnode_unavailable()
@@ -202,7 +201,6 @@ extern struct	license_used  usedlicenses;
 extern struct	license_block licenses;
 extern struct	license_used  usedlicenses;
 extern int tpp_network_up; /* from pbsd_main.c - used only in case of TPP */
-extern struct work_task *global_ping_task;
 
 extern pbs_list_head svr_unlicensedjobs;
 
@@ -362,10 +360,53 @@ tinsert2(const u_long key1, const u_long key2, mominfo_t *momp, struct tree **ro
 }
 
 /**
+ * @brief 
+ * send IS_NULL to mom along with rpp_retry and rpp_highwater
+ * values.
+ *
+ * @param[in] pmom - pointer to mom
+ *
+ */
+static void
+reply_hellosvr(mominfo_t *pmom)
+{
+	mom_svrinfo_t *psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
+	struct	sockaddr_in	*addr;
+	int	ret;
+
+	ret = is_compose(psvrmom->msr_stream, IS_NULL);
+	if (ret != DIS_SUCCESS)
+		goto err;
+
+	/*
+	** Send rpp_retry and rpp_highwater values with IS_NULL.
+	** Old versions of MOM will ignore extra data.
+	*/
+	ret = diswsi(psvrmom->msr_stream, rpp_retry);
+	if (ret != DIS_SUCCESS)
+		goto err;
+	ret = diswsi(psvrmom->msr_stream, rpp_highwater);
+	if (ret != DIS_SUCCESS)
+		goto err;
+
+	if (dis_flush(psvrmom->msr_stream) != 0)
+		goto err;
+
+	return;
+
+	ret = DIS_NOCOMMIT;
+
+err:
+	addr = tpp_getaddr(psvrmom->msr_stream);
+	snprintf(log_buffer, sizeof(log_buffer), "%s %d to %s(%s)",
+		dis_emsg[ret], errno, pmom->mi_host, netaddr(addr));
+	log_err(-1, __func__, log_buffer);
+	stream_eof(psvrmom->msr_stream, ret, "ping no ack");
+}
+
+/**
  * @brief
  *  	delete node with given key
- * @see
- * 		ping_a_mom
  *
  * @param[in]	key1	-	key to be located
  * @param[in]	key2	-	key to be located
@@ -957,7 +998,7 @@ momptr_down(mominfo_t *pmom, char *why)
 	int		 setwktask = 0;
 	int		 is_provisioning = 0;
 
-	psvrmom->msr_state |= (INUSE_DOWN | INUSE_NEEDS_HELLO_PING);
+	psvrmom->msr_state |= INUSE_DOWN;
 
 	/* log message if node just down or been down for an hour */
 	/* mark mom down and vnodes down as well                  */
@@ -978,7 +1019,7 @@ momptr_down(mominfo_t *pmom, char *why)
 #ifndef NAS /* localmod 023 */
 	/* do not display 'node down' msg and comment */
 	if (is_provisioning) {
-		set_all_state(pmom, 1, INUSE_DOWN | INUSE_NEEDS_HELLO_PING, NULL,
+		set_all_state(pmom, 1, INUSE_DOWN, NULL,
 			Set_All_State_Regardless);
 	} else {
 #endif /* localmod 023 */
@@ -992,7 +1033,7 @@ momptr_down(mominfo_t *pmom, char *why)
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
 			LOG_ALERT, pmom->mi_host, log_buffer);
 
-		set_all_state(pmom, 1, INUSE_DOWN | INUSE_NEEDS_HELLO_PING, log_buffer,
+		set_all_state(pmom, 1, INUSE_DOWN, log_buffer,
 			Set_ALL_State_All_Down);
 #ifndef NAS /* localmod 023 */
 	}
@@ -1087,6 +1128,10 @@ send_ip_addrs_to_mom(int stream)
 	ret = is_compose(stream, IS_CLUSTER_ADDRS2);
 	if (ret != DIS_SUCCESS)
 		return (ret);
+
+	if (get_max_servers() > 1)
+		return (dis_flush(stream));
+
 	for (j = 0; j < pbs_iplist->li_nrowsused; j++) {
 #ifdef DEBUG
 		unsigned long	ipaddr;
@@ -1106,338 +1151,6 @@ send_ip_addrs_to_mom(int stream)
 			return (ret);
 	}
 	return (dis_flush(stream));
-}
-
-/**
- * @brief Find out whether a mom needs a ping, and if so,
- * 		which message to send (IS_HELLO, or IS_NULL)
- *
- * @param[in] pmom - pointer to mom to ping
- * @param[in] force_hello - Whether to force a hello sequence with the mom
- * 			The force_hello flag will only be set in the case of RESTART
- * @param[in] once - Whether it is a one shot ping which is done when a new device registers with comm
- *                   In this case a new ping series is not create, but just a single ping done
- *
- * @return - The msg to send to the mom
- * @retval  IS_HELLO - mom needs a hello message
- * @retval  IS_HELLO_NO_INVENTORY - mom needs a hello message telling
- * 		her not to report her inventory
- * @retval  IS_NULL  - mom has established communications, send only a heartbeat (IS_NULL)
- * @retval  -1       - mom does not need to be sent any ping messages yet
- *
- */
-static int
-mom_ping_need(mominfo_t *pmom, int force_hello, int once)
-{
-	mom_svrinfo_t   *psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
-	struct pbsnode  *np;
-	struct pbssubn  *snp;
-	int             do_ping = 0;
-	int             nchild;
-	int             com;
-
-	if (psvrmom->msr_state & INUSE_INIT) {
-		/* Mom has been sent IS_HOST_TO_VNODE */
-		/* Ignore her until she replies or it times out      */
-
-		if (time_now < (psvrmom->msr_timeinit + 2 * svr_ping_rate))
-			return -1; /* no ping/hello now */
-
-		/* too old, reset to send HELLO */
-		set_all_state(pmom, 0, INUSE_INIT, NULL, Set_ALL_State_All_Down);
-		set_all_state(pmom, 1, INUSE_NEEDS_HELLO_PING, NULL,
-			Set_ALL_State_All_Down);
-		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_NODE, LOG_NOTICE,
-			pmom->mi_host, "Node failed to reply to vnode map update");
-	}
-
-	/* Query each vnode associated to the Mom */
-	for (nchild = 0; (nchild < psvrmom->msr_numvnds) && (do_ping==0); ++nchild) {
-		np = psvrmom->msr_children[nchild];
-		if (np->nd_state & (INUSE_OFFLINE|INUSE_OFFLINE_BY_MOM)) {
-			if (force_hello) {
-				/* In the case where a mom is marked as "offline" */
-				/* and there was a restart (causing force_hello to */
-				/* be set), set do_ping to 1 so that we cause the */
-				/* server to ping the offline mom to see if her */
-				/* state has changed */
-				do_ping =1;
-			} else {
-				/* ping as long as there are still jobs running */
-				/* on the node */
-				for (snp=np->nd_psn; snp; snp=snp->next) {
-					if (snp->jobs) {
-						do_ping = 1;
-						break;
-					}
-				}
-			}
-		} else {
-			do_ping = 1;
-		}
-
-		if (np->nd_state & INUSE_UNRESOLVABLE)
-			do_ping = 0; /* never ping if state is unreachable */
-	}
-
-	if (do_ping == 0) {
-		/* no jobs on offline node, don't ping */
-		psvrmom->msr_state |= INUSE_NEEDS_HELLO_PING;
-		return -1;
-	}
-
-	if (psvrmom->msr_stream < 0) {
-		unsigned int port;
-
-		port = pmom->mi_rmport;
-		if ((psvrmom->msr_state & INUSE_DOWN) == 0)
-			momptr_down(pmom, "ping no stream");
-		psvrmom->msr_stream = tpp_open(pmom->mi_host, port);
-		if (psvrmom->msr_stream == -1) {
-			sprintf(log_buffer, "tpp_open to %s, port %u",
-				pmom->mi_host, port);
-			log_err(errno, __func__, log_buffer);
-			return -1;
-		}
-		com = IS_HELLO;
-#ifdef NAS /* localmod 005 */
-		tinsert2((u_long)psvrmom->msr_stream, 0ul, pmom, &streams);
-#else
-		tinsert2((u_long)psvrmom->msr_stream, 0, pmom, &streams);
-#endif /* localmod 005 */
-	} else {
-		if (once) {
-			/* in case of one shot ping, don't ping recently pinged devices */
-			DBPRT(("%s: time_now = %lu, timepinged=%lu, ping_nodes_rate=%d, difference=%lu\n",
-				__func__, (unsigned long)time_now,
-				(unsigned long)psvrmom->msr_timepinged, ping_nodes_rate,
-				(unsigned long)(time_now - psvrmom->msr_timepinged)))
-			if (time_now - psvrmom->msr_timepinged < ping_nodes_rate) {
-				DBPRT(("%s: **** NOT PINGING ***\n", __func__))
-				return -1; /* skip this mom since it was pinged recently. This is to avoid a DOS attack */
-			}
-		}
-		com = IS_NULL;
-	}
-
-	DBPRT(("%s: **** ping %s on port %u, comm=%s\n", __func__, pmom->mi_host, pmom->mi_port, (com == IS_HELLO)? "IS_HELLO":"IS_NULL"));
-
-	if (psvrmom->msr_state & INUSE_NEEDS_HELLO_PING)
-		com = IS_HELLO;
-	else if (psvrmom->msr_state & INUSE_NEED_ADDRS) {
-		/* just need to send IP_CLUSTER_ADDRS2 */
-		if (send_ip_addrs_to_mom(psvrmom->msr_stream) != DIS_SUCCESS) {
-			sprintf(log_buffer, "Unable to send IP addresses on stream %d",
-				psvrmom->msr_stream);
-			log_err(-1, __func__, log_buffer);
-		}
-		psvrmom->msr_state &= ~INUSE_NEED_ADDRS;
-	}
-
-	if (com == IS_HELLO) {
-		/* know that a HELLO is needed, but with or without inventory? */
-		if (psvrmom->msr_vnode_pool != 0) {
-			vnpool_mom_t *ppool;
-
-			ppool = find_vnode_pool(pmom);
-			if (ppool != NULL) {
-				/* We found the vnode_pool matching this mom.
-				 * Now check if she's the inventory_mom
-				 */
-				if (ppool->vnpm_inventory_mom != pmom) {
-					/* not the "one" Mom that sends inventory */
-					com = IS_HELLO_NO_INVENTORY;
-				}
-			}
-		}
-	}
-
-	psvrmom->msr_timepinged = time_now; /* record the time when it was last pinged */
-	return com;
-}
-
-/**
- * @brief ping a single mom.
- *
- * @param[in] pmom - pointer to mom to ping
- * @param[in] force_hello - Whether to force a hello sequence with the mom
- * 			The force_hello flag will only be set in the case of RESTART
- * @param[in] once - one shot ping?
- *
- */
-static void
-ping_a_mom(mominfo_t *pmom, int force_hello, int once)
-{
-	mom_svrinfo_t *psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
-	struct	sockaddr_in	*addr;
-	int	ret;
-	int	com;
-
-	com = mom_ping_need(pmom, force_hello, once);
-	if (com == -1)
-		return; /* this mom does not need a ping */
-
-	ret = is_compose(psvrmom->msr_stream, com);
-	if (ret != DIS_SUCCESS)
-		goto err;
-
-	if (com == IS_NULL) {
-		/*
-		 ** Send rpp_retry and rpp_highwater values with IS_NULL.
-		 ** Old versions of MOM will ignore extra data.
-		 */
-		ret = diswsi(psvrmom->msr_stream, rpp_retry);
-		if (ret != DIS_SUCCESS)
-			goto err;
-		ret = diswsi(psvrmom->msr_stream, rpp_highwater);
-		if (ret != DIS_SUCCESS)
-			goto err;
-	}
-
-	if (dis_flush(psvrmom->msr_stream) == 0) {
-		/*
-		 * If the message later fails to be delivered, with TPP, the network is deemed broken,
-		 * and the stream would automatically get closed and everything will start afresh.
-		 * It is therefore okay for us to reset INUSE_NEEDS_HELLO_PING here.
-		 */
-		if (com == IS_HELLO) {
-			/* reset the INUSE_NEEDS_HELLO_PING, so we don't send repeated hellos */
-			psvrmom->msr_state &= ~INUSE_NEEDS_HELLO_PING;
-		}
-
-		return;
-	}
-	ret = DIS_NOCOMMIT;
-
-err:
-	addr = tpp_getaddr(psvrmom->msr_stream);
-	snprintf(log_buffer, sizeof(log_buffer), "%s %d to %s(%s)",
-		dis_emsg[ret], errno, pmom->mi_host, netaddr(addr));
-	log_err(-1, __func__, log_buffer);
-
-	stream_eof(psvrmom->msr_stream, ret, "ping no ack");
-}
-
-/**
- * @brief In case of TPP multicast mode, this function flushes the data to be sent out
- * 	to all the moms that are determined to be part of the mcast message
- *
- * @param[in] mtfd - The TPP multicast channel to flush
- * @param[in] com  - The message (IS_HELLO, IS_NULL) to be sent
- *
- */
-static void
-ping_flush_mcast(int mtfd, int com)
-{
-	int                  ret;
-	int                  *strms;
-	int                  count;
-	int                  i;
-	mominfo_t            *pmom;
-	mom_svrinfo_t        *psvrmom;
-	struct	sockaddr_in  *addr;
-
-	ret = is_compose(mtfd, com);
-	if (ret != DIS_SUCCESS)
-		goto err;
-
-	if (com == IS_NULL) {
-		/*
-		 ** Send rpp_retry and rpp_highwater values with IS_NULL.
-		 ** Old versions of MOM will ignore extra data.
-		 */
-		ret = diswsi(mtfd, rpp_retry);
-		if (ret != DIS_SUCCESS)
-			goto err;
-		ret = diswsi(mtfd, rpp_highwater);
-		if (ret != DIS_SUCCESS)
-			goto err;
-	}
-
-	if (dis_flush(mtfd) == 0) {
-		/*
-		 * If the message later fails to be delivered, with TPP, the network is deemed broken,
-		 * and the stream would automatically get closed and everything will start afresh.
-		 * It is therefore okay for us to reset INUSE_NEEDS_HELLO_PING here.
-		 *
-		 */
-		if (com == IS_HELLO) {
-			strms = tpp_mcast_members(mtfd, &count);
-			/* reset the INUSE_NEEDS_HELLO_PING, so we don't send repeated hellos */
-			for(i = 0; i < count; i++) {
-				if ((pmom = tfind2((u_long) strms[i], 0, &streams))) {
-					psvrmom = (mom_svrinfo_t *) (pmom->mi_data);
-					psvrmom->msr_state &= ~INUSE_NEEDS_HELLO_PING;
-				}
-			}
-		}
-		return;
-	}
-	ret = DIS_NOCOMMIT;
-
-err:
-	strms = tpp_mcast_members(mtfd, &count);
-	/* reset the INUSE_NEEDS_HELLO_PING, so we don't send repeated hellos */
-	for(i = 0; i < count; i++) {
-		if ((pmom = tfind2((u_long) strms[i], 0, &streams))) {
-			psvrmom = (mom_svrinfo_t *) (pmom->mi_data);
-			psvrmom->msr_state &= ~INUSE_NEEDS_HELLO_PING;
-			/* find the respective mom from the stream */
-			addr = tpp_getaddr(psvrmom->msr_stream);
-			snprintf(log_buffer, sizeof(log_buffer), "%s %d to %s(%s)",
-				dis_emsg[ret], errno, pmom->mi_host, netaddr(addr));
-			log_err(-1, __func__, log_buffer);
-
-			stream_eof(psvrmom->msr_stream, ret, "ping no ack");
-		}
-	}
-}
-
-/**
- * @brief The TPP multicast version of ping_a_mom
- *
- * This is not used when its known that a single mom will be pinged.
- * This is only used from the periodic ping_nodes which typically sends
- * a ping message to a lot of moms.
- *
- * @param[in] pmom - The mom to ping
- * @param[in] force_hello - Whether to force a HELLO message to this mom
- * @param[in] mtfd_ishello - The TPP channel to add moms as members for those that need IS_HELLO
- * @param[in] mtfd_isnull  - The TPP channel to add moms as members for those that need IS_NULL
- * @param[in] mtfd_ishello_no_inv - The TPP channel to add moms as members for
- *		those that need IS_HELLO_NO_INVENTORY
- * @param[in] once         - One shot ping?
- *
- * @see ping_nodes
- * @see ping_flush_mcast
- *
- */
-static void
-ping_a_mom_mcast(mominfo_t *pmom, int force_hello, int mtfd_ishello, int mtfd_isnull, int mtfd_ishello_no_inv, int once)
-{
-	mom_svrinfo_t *psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
-	int rc;
-	int com;
-
-	com = mom_ping_need(pmom, force_hello, once);
-	if (com == -1)
-		return; /* this mom does not need a ping */
-
-	if (com == IS_NULL)
-		rc = tpp_mcast_add_strm(mtfd_isnull, psvrmom->msr_stream);
-	else if (com == IS_HELLO_NO_INVENTORY)
-		rc = tpp_mcast_add_strm(mtfd_ishello_no_inv, psvrmom->msr_stream);
-	else
-		rc = tpp_mcast_add_strm(mtfd_ishello, psvrmom->msr_stream);
-
-	if (rc == -1) {
-		snprintf(log_buffer, sizeof(log_buffer),
-				 "Failed to add mom at %s:%d to ping mcast", pmom->mi_host, pmom->mi_port);
-		log_err(-1, __func__, log_buffer);
-		tpp_close(psvrmom->msr_stream);
-		tdelete2((u_long)psvrmom->msr_stream, 0, &streams);
-		psvrmom->msr_stream = -1;
-	}
 }
 
 /**
@@ -3193,8 +2906,7 @@ stream_eof(int stream, int ret, char *msg)
 		((mom_svrinfo_t *)(mp->mi_data))->msr_stream = -1;
 
 		/* Since stream is now closed, reset the intermediate
-		 * state INUSE_INIT. This would allow ping_a_mom
-		 * to be functional
+		 * state INUSE_INIT.
 		 */
 		((mom_svrinfo_t *) (mp->mi_data))->msr_state &= ~INUSE_INIT;
 
@@ -3240,88 +2952,184 @@ mark_nodes_unknown(int all)
 				psvrmom->msr_stream = -1;
 
 				/* Since stream is being closed, reset the intermediate
-				 * state INUSE_INIT. This would allow ping_a_mom
-				 * to be functional
+				 * state INUSE_INIT.
 				 */
 				psvrmom->msr_state &= ~INUSE_INIT;
-				psvrmom->msr_state |= INUSE_NEEDS_HELLO_PING | INUSE_UNKNOWN | INUSE_MARKEDDOWN;
+				psvrmom->msr_state |= INUSE_UNKNOWN | INUSE_MARKEDDOWN;
 			}
 		}
 	}
 }
 
 /**
+ * @brief In case of TPP multicast mode, this function flushes the data to be sent out
+ * 	to all the moms that are determined to be part of the mcast message
+ *
+ * @param[in] mtfd - The TPP multicast channel to flush
+ *
+ */
+static int
+flush_mcast_ISNULL(int mtfd)
+{
+	int                  ret;
+	int                  *strms;
+	int                  count;
+	int                  i;
+	mominfo_t            *pmom;
+	mom_svrinfo_t        *psvrmom;
+	struct	sockaddr_in  *addr;
+
+	ret = is_compose(mtfd, IS_NULL);
+	if (ret != DIS_SUCCESS)
+		goto err;
+
+	/*
+	** Send rpp_retry and rpp_highwater values with IS_NULL.
+	** Old versions of MOM will ignore extra data.
+	*/
+	ret = diswsi(mtfd, rpp_retry);
+	if (ret != DIS_SUCCESS)
+		goto err;
+	ret = diswsi(mtfd, rpp_highwater);
+	if (ret != DIS_SUCCESS)
+		goto err;
+
+	if (dis_flush(mtfd) == 0) {
+		/*
+		 * If the message later fails to be delivered, with TPP, the network is deemed broken,
+		 * and the stream would automatically get closed and everything will start afresh.
+		 * It is therefore okay for us to reset INUSE_NEEDS_HELLO_PING here.
+		 *
+		 */
+		return 0;
+	}
+	ret = DIS_NOCOMMIT;
+
+err:
+	strms = tpp_mcast_members(mtfd, &count);
+	for(i = 0; i < count; i++) {
+		if ((pmom = tfind2((u_long) strms[i], 0, &streams))) {
+			psvrmom = (mom_svrinfo_t *) (pmom->mi_data);
+			/* find the respective mom from the stream */
+			addr = tpp_getaddr(psvrmom->msr_stream);
+			snprintf(log_buffer, sizeof(log_buffer), "%s %d to %s(%s)",
+				dis_emsg[ret], errno, pmom->mi_host, netaddr(addr));
+			log_err(-1, __func__, log_buffer);
+			stream_eof(psvrmom->msr_stream, ret, "ping no ack");
+		}
+	}
+	return ret;
+}
+
+/**
+ * @brief The TPP multicast version of ping_a_mom
+ *
+ * This is not used when its known that a single mom will be pinged.
+ * This is only used from the periodic ping_nodes which typically sends
+ * a ping message to a lot of moms.
+ *
+ * @param[in] pmom - The mom to ping
+ * @param[in] mtfd_isnull  - The TPP channel to add moms as members for those that need IS_NULL
+ *
+ */
+static void
+mom_mcast(mominfo_t *pmom, int mtfd_isnull)
+{
+	mom_svrinfo_t *psvrmom = (mom_svrinfo_t *)(pmom->mi_data);
+	int rc;
+
+	rc = tpp_mcast_add_strm(mtfd_isnull, psvrmom->msr_stream);
+
+	if (rc == -1) {
+		snprintf(log_buffer, sizeof(log_buffer),
+				 "Failed to add mom at %s:%d to ping mcast", pmom->mi_host, pmom->mi_port);
+		log_err(-1, __func__, log_buffer);
+		tpp_close(psvrmom->msr_stream);
+		tdelete2((u_long)psvrmom->msr_stream, 0, &streams);
+		psvrmom->msr_stream = -1;
+	}
+}
+
+/**
  * @brief
- * 		Send a ping to any node that is in an unknown stat.
+ * 		Send rpp_stream and rpp_highwater to all the moms
+ * 
+ * @param[in]	cmd	- what message needs to be multicasted.
+ *
+ * @return	void
+ */
+void
+mcast_moms(int cmd)
+{
+	int	i;
+	int                  *strms;
+	mominfo_t            *pmom;
+	mom_svrinfo_t        *psvrmom;
+	struct	sockaddr_in  *addr;
+	int	ret = 0;
+	int	count = 0;
+
+	DBPRT(("%s: entered\n", __func__))
+
+	if (tpp_network_up == 1) {
+		int mtfd;
+
+		/* open the tpp mcast channel here */
+		if ((mtfd = tpp_mcast_open()) == -1) {
+			log_err(-1, __func__, "Failed to open TPP mcast channel for mom pings");
+			return;
+		}
+
+		for (i = 0; i < mominfo_array_size; i++) {
+			if (cmd == IS_NULL) {
+				if (mominfo_array[i]) {
+					mom_mcast(mominfo_array[i], mtfd);
+				}
+			} else if (cmd == IS_CLUSTER_ADDRS2) {
+				if (mominfo_array[i] && ((mom_svrinfo_t *)(mominfo_array[i]->mi_data))->msr_state & INUSE_NEED_ADDRS) {
+					mom_mcast(mominfo_array[i], mtfd);
+				}	
+			}
+		}
+
+		if (cmd == IS_NULL)
+			ret = flush_mcast_ISNULL(mtfd);
+		else if (cmd == IS_CLUSTER_ADDRS2)
+			ret = send_ip_addrs_to_mom(mtfd);
+		if (ret != DIS_SUCCESS) {
+			strms = tpp_mcast_members(mtfd, &count);
+			for(i = 0; i < count; i++) {
+				if ((pmom = tfind2((u_long) strms[i], 0, &streams))) {
+					psvrmom = (mom_svrinfo_t *) (pmom->mi_data);
+					/* find the respective mom from the stream */
+					addr = tpp_getaddr(psvrmom->msr_stream);
+					snprintf(log_buffer, sizeof(log_buffer), "%s %d to %s(%s)",
+						dis_emsg[ret], errno, pmom->mi_host, netaddr(addr));
+					log_err(-1, __func__, log_buffer);
+					stream_eof(psvrmom->msr_stream, ret, "ping no ack");
+				}
+			}
+		}
+		tpp_mcast_close(mtfd);
+	}
+}
+
+/**
+ * @brief
+ * 		Send IS_CLUSTER_ADDR2 in case of single server mode
  * @par
- *		If wt_parm1 is NULL, set up a worktask to ping again.
+ *		If wt_parm1 is NULL, set up a worktask to do again.
  *
  * @param[in]	ptask	-	work task structure.
  *
  * @return	void
  */
 void
-ping_nodes(struct work_task *ptask)
+send_nodes_addr(struct work_task *ptask)
 {
-	int	i;
-	int	once = 0;
-
-	DBPRT(("%s: entered\n", __func__))
-
 	if (!ptask)
-		once = 1; /* not main ping series, just an one shot ping for any new devices */
-
-	/*
-	 * If this is configured to talk TCP, then do the
-	 * ping functionality only if tpp_network_up global variable
-	 * to 1. This is set to 1 at pbsd_main by the TPP router connection
-	 * established handler
-	 */
-	if (tpp_network_up == 1) {
-		int mtfd_ishello;
-		int mtfd_isnull;
-		int mtfd_ishello_no_inv;
-
-		/* open the tpp mcast channel here */
-		if ((mtfd_ishello = tpp_mcast_open()) == -1) {
-			log_err(-1, __func__, "Failed to open TPP mcast channel for mom pings");
-			return;
-		}
-
-		/* open the tpp mcast channel here */
-		if ((mtfd_isnull = tpp_mcast_open()) == -1) {
-			tpp_mcast_close(mtfd_ishello);
-			log_err(-1, __func__, "Failed to open TPP mcast channel for mom pings");
-			return;
-		}
-
-		/* open the tpp mcast channel here */
-		if ((mtfd_ishello_no_inv = tpp_mcast_open()) == -1) {
-			tpp_mcast_close(mtfd_ishello);
-			tpp_mcast_close(mtfd_isnull);
-			log_err(-1, __func__, "Failed to open TPP mcast channel for mom pings");
-			return;
-		}
-
-		for (i = 0; i < mominfo_array_size; i++) {
-			if (mominfo_array[i]) {
-				ping_a_mom_mcast(mominfo_array[i], 0,
-					mtfd_ishello, mtfd_isnull,
-					mtfd_ishello_no_inv, once);
-			}
-		}
-
-		ping_flush_mcast(mtfd_ishello, IS_HELLO);
-		ping_flush_mcast(mtfd_ishello_no_inv, IS_HELLO_NO_INVENTORY);
-		ping_flush_mcast(mtfd_isnull, IS_NULL);
-
-		tpp_mcast_close(mtfd_ishello);
-		tpp_mcast_close(mtfd_isnull);
-		tpp_mcast_close(mtfd_ishello_no_inv);
-	}
-
-	if (ptask != NULL)
-		global_ping_task = set_task(WORK_Timed, time_now + ping_nodes_rate, ping_nodes, NULL);
+		return;
+	mcast_moms(IS_CLUSTER_ADDRS2);
 }
 
 /**
@@ -4467,8 +4275,7 @@ is_request(int stream, int version)
 	mominfo_t		*pmom;
 	mom_svrinfo_t		*psvrmom;
 	int			 s;
-	int			 stm;
-	char			restartmsg[]="Mom restarted on host";
+	char			hellosvrmsg[]="Mom sent hellosvr on host";
 	char			*val;
 	unsigned long		 oldstate;
 	vnl_t			*vnlp;			/* vnode list */
@@ -4502,33 +4309,20 @@ is_request(int stream, int version)
 	if (ret != DIS_SUCCESS)
 		goto badcon;
 
-	if (command == IS_RESTART) {
+	if (command == IS_HELLOSVR) {
 		port = disrui(stream, &ret);
 		if (ret != DIS_SUCCESS)
 			goto badcon;
 
-		DBPRT(("%s: IS_RESTART port %lu\n", __func__, port))
+		DBPRT(("%s: IS_HELLOSVR port %lu\n", __func__, port))
 
 		if ((pmom = tfind2(ipaddr, port, &ipaddrs)) == NULL)
 			goto badcon;
 
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
-			LOG_NOTICE, pmom->mi_host, restartmsg);
+			LOG_NOTICE, pmom->mi_host, hellosvrmsg);
 
-		stm = ((mom_svrinfo_t *)(pmom->mi_data))->msr_stream;
-		if (stm >= 0) {
-			DBPRT(("%s: stream %d from %s:%d already open on %d\n",
-				__func__, stream, pmom->mi_host,
-				ntohs(addr->sin_port), stm))
-			tpp_close(stm);
-#ifdef NAS /* localmod 005 */
-			tdelete2((u_long)stm, 0ul, &streams);
-#else
-			tdelete2((u_long)stm, 0, &streams);
-#endif /* localmod 005 */
-		}
-		((mom_svrinfo_t *)(pmom->mi_data))->msr_state |=
-			INUSE_NEEDS_HELLO_PING|INUSE_UNKNOWN;
+		((mom_svrinfo_t *)(pmom->mi_data))->msr_state |= INUSE_UNKNOWN;
 
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 		if (((mom_svrinfo_t *)(pmom->mi_data))->msr_numjobs > 0)
@@ -4555,13 +4349,17 @@ is_request(int stream, int version)
 			}
 		}
 
-		/* do not need to tdelete2() this stream, it was never inserted */
-		tpp_close(stream);
-
-		((mom_svrinfo_t *)(pmom->mi_data))->msr_stream = -1;
+		/* we save this stream for future communications */
+		((mom_svrinfo_t *)(pmom->mi_data))->msr_stream = stream;
 		((mom_svrinfo_t *)(pmom->mi_data))->msr_state &= ~INUSE_INIT;
+#ifdef NAS /* localmod 005 */
+		tinsert2((u_long)stream, 0ul, pmom, &streams);
+#else
+		tinsert2((u_long)stream, 0, pmom, &streams);
+#endif /* localmod 005 */
 
-		ping_a_mom(pmom, 1, 0);
+		tpp_eom(stream);
+		reply_hellosvr(pmom);
 		return;
 
 	} else {
@@ -4591,14 +4389,6 @@ found:
 			DBPRT(("%s: IS_NULL\n", __func__))
 			break;
 
-		case IS_HELLO:
-			/* Old, pre 8.0, reply from Mom */
-			set_all_state(pmom, 0,
-				INUSE_DOWN|INUSE_UNKNOWN|INUSE_NEEDS_HELLO_PING,
-				NULL, Set_All_State_Regardless);
-			psvrmom->msr_timedown = 0;
-			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
-				LOG_NOTICE, pmom->mi_host, node_up);
 			/* fall into HELLO2, HELLO3 case */
 		case IS_HELLO2:
 		case IS_HELLO3:
@@ -4622,8 +4412,7 @@ found:
 			/* and set initializing and the time		     */
 
 			set_all_state(pmom, 0,
-				INUSE_UNKNOWN|INUSE_NEEDS_HELLO_PING|
-				INUSE_NEED_ADDRS, NULL,
+				INUSE_UNKNOWN|INUSE_NEED_ADDRS, NULL,
 				Set_All_State_Regardless);
 			set_all_state(pmom, 1, INUSE_DOWN|INUSE_INIT, NULL,
 				Set_ALL_State_All_Down);
@@ -4667,22 +4456,9 @@ found:
 
 			/* Send the Mom addresses		    */
 			/* Mom will respond when she receives these */
-
 			ret = send_ip_addrs_to_mom(stream);
 			if (ret != DIS_SUCCESS)
 				goto err;
-
-			if (command == IS_HELLO) {
-				/* pre-8.0 Mom - should delete this in a release or 2 */
-				set_all_state(pmom, 0, INUSE_DOWN|INUSE_UNKNOWN|
-					INUSE_NEEDS_HELLO_PING|INUSE_INIT|
-					INUSE_NEED_ADDRS,
-					NULL, Set_All_State_Regardless);
-				psvrmom->msr_timedown = 0;
-				psvrmom->msr_timeinit = 0;
-				log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_NODE,
-					LOG_NOTICE, pmom->mi_host, node_up);
-			}
 
 			break;
 
@@ -5121,8 +4897,7 @@ found:
 				psvrmom->msr_state &= ~INUSE_MARKEDDOWN;
 
 			set_all_state(pmom, 0, INUSE_DOWN|INUSE_UNKNOWN|
-				INUSE_NEEDS_HELLO_PING|INUSE_INIT|
-				INUSE_NEED_ADDRS,
+				INUSE_INIT|INUSE_NEED_ADDRS,
 				NULL, Set_All_State_Regardless);
 
 			/* log a node up message only if it was not marked

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -4261,7 +4261,6 @@ is_request(int stream, int version)
 	unsigned long		port;
 	struct	sockaddr_in	*addr;
 	struct	pbsnode		*np = NULL;
-	int			 hello_opts;
 	attribute		*pala;
 	resource_def		*prd;
 	resource		*prc;
@@ -4411,9 +4410,6 @@ found:
 				psvrmom->msr_wktask = 0;
 			}
 
-			/* clear INUSE_NEEDS_HELL0 to prevent resending of HELLO */
-			/* and set initializing and the time		     */
-
 			set_all_state(pmom, 0,
 				INUSE_UNKNOWN|INUSE_NEED_ADDRS, NULL,
 				Set_All_State_Regardless);
@@ -4423,29 +4419,8 @@ found:
 				log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_NODE, LOG_INFO,
 					pmom->mi_host, "Setting host to Initialize");
 
-			/* Now process the optional data sent along on the HELLO4 */
-			/* Must be dealt with in the order sent (defined bit wise */
-			/* See resmom/mom_server.c				  */
-
-			/* get the options set */
-			hello_opts = disrui(stream, &ret);
-			if (ret != DIS_SUCCESS)
-				goto err;
-
-			if (hello_opts & HELLO4_vmap_version) {
-				/* Mom sending vnodemap file info which is */
-				/* no longer used,  just read and ignore   */
-				(void)disrul(stream, &ret);
-				if (ret != DIS_SUCCESS)
-					goto err;
-				(void)disrsi(stream, &ret);
-				if (ret != DIS_SUCCESS)
-					goto err;
-			}
-			if (hello_opts & HELLO4_running_jobs) {
-				/* validate jobs Mom reported against what I have */
-				mom_running_jobs(stream);
-			}
+			/* validate jobs Mom reported against what I have */
+			mom_running_jobs(stream);
 			/*
 			 * respond to HELLO from Mom by sending her optional vmap and
 			 * all addresses of all Moms

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -416,7 +416,7 @@ do_tpp(int stream)
 	DIS_tpp_funcs();
 	proto = disrsi(stream, &ret);
 	if (ret != DIS_SUCCESS) {
-		DBPRT(("rpp read failure: ret: %d, proto: %d\n", ret, proto));
+		DBPRT(("tpp read failure: ret: %d, proto: %d\n", ret, proto));
 		stream_eof(stream, ret, NULL);
 		return;
 	}

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -149,7 +149,6 @@ extern int chk_and_update_db_svrhost();
 #endif /* localmod 005 */
 
 extern int put_sched_cmd(int sock, int cmd, char *jobid);
-extern void setup_ping(int delay);
 
 /* External data items */
 extern  pbs_list_head svr_requests;
@@ -309,7 +308,6 @@ static char    *suffix_slash = "/";
 static int	brought_up_alt_sched = 0;
 void stop_db();
 char *db_err_msg = NULL;
-extern void		ping_nodes(struct work_task *ptask);
 extern void mark_nodes_unknown(int);
 
 /*
@@ -335,7 +333,6 @@ net_restore_handler(void *data)
 	if (tpp_log_func)
 		tpp_log_func(LOG_INFO, NULL, "net restore handler called");
 	tpp_network_up = 1;
-	ping_nodes(NULL);
 }
 
 /**
@@ -419,6 +416,7 @@ do_tpp(int stream)
 	DIS_tpp_funcs();
 	proto = disrsi(stream, &ret);
 	if (ret != DIS_SUCCESS) {
+		DBPRT(("rpp read failure: ret: %d, proto: %d\n", ret, proto));
 		stream_eof(stream, ret, NULL);
 		return;
 	}
@@ -762,7 +760,6 @@ main(int argc, char **argv)
 	int			do_mlockall = 0;
 #endif	/* _POSIX_MEMLOCK */
 	extern char		**environ;
-	extern void		ping_nodes(struct work_task *ptask);
 
 	static struct {
 		char *it_name;
@@ -1614,9 +1611,6 @@ try_db_again:
 	log_event(PBSEVENT_SYSTEM | PBSEVENT_FORCE, PBS_EVENTCLASS_SERVER,
 		LOG_INFO, msg_daemonname, log_buffer);
 
-
-	/* setup the periodic ping_nodes functionality */
-	setup_ping(0);
 
 	/*
 	 * Now at last, we are read to do some batch work, the

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1594,26 +1594,3 @@ get_servername(unsigned int *port)
 	return name;
 }
 
-/**
- * @brief
- * 		choosing one server in random if a failover server is already set up.
- *
- * @param[out] port - Passed through to parse_servername(), not modified here.
- *
- * @return char *
- * @return NULL - failure
- * @retval !NULL - pointer to server name
- */
-char *
-get_servername_random(unsigned int *port)
-{
-
-	if (rand() % 2 == 0)
-		return get_servername(port);
-	else {
-		if (pbs_conf.pbs_secondary)
-			return parse_servername(pbs_conf.pbs_secondary, port);
-		return NULL;
-	}
-}
-

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1593,3 +1593,27 @@ get_servername(unsigned int *port)
 
 	return name;
 }
+
+/**
+ * @brief
+ * 		choosing one server in random if a failover server is already set up.
+ *
+ * @param[out] port - Passed through to parse_servername(), not modified here.
+ *
+ * @return char *
+ * @return NULL - failure
+ * @retval !NULL - pointer to server name
+ */
+char *
+get_servername_random(unsigned int *port)
+{
+
+	if (rand() % 2 == 0)
+		return get_servername(port);
+	else {
+		if (pbs_conf.pbs_secondary)
+			return parse_servername(pbs_conf.pbs_secondary, port);
+		return NULL;
+	}
+}
+

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -123,7 +123,6 @@
 #define PERM_MANAGER (ATR_DFLAG_MGWR | ATR_DFLAG_MGRD)
 #define PERM_OPorMGR (ATR_DFLAG_MGWR | ATR_DFLAG_MGRD | ATR_DFLAG_OPRD | ATR_DFLAG_OPWR)
 
-struct work_task *global_ping_task = NULL;
 pntPBS_IP_LIST pbs_iplist = NULL;
 
 AVL_IX_DESC *node_tree = NULL;
@@ -3189,7 +3188,6 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 			if ((rc == PBSE_UNKNODE) && (server.sv_attr[(int)SRV_ATR_State].at_val.at_long == SV_STATE_INIT)) {
 				/*
 				 * mark node as INUSE_UNRESOLVABLE, pbsnodes will show unresolvable state
-				 * flag INUSE_UNRESOLVABLE will ensure ping_a_mom will never ping for this node
 				 */
 				set_vnode_state(pnode, INUSE_UNRESOLVABLE | INUSE_DOWN, Nd_State_Set);
 
@@ -3588,22 +3586,7 @@ struct batch_request *preq;
 
 
 	reply_ack(preq);		/*request completely successful*/
-}
-/**
- * @brief
- * 		setup_ping	- set up a task to ping nodes.
- *
- * @param[in] delay - delay after which to ping.
- *
- */
-void
-setup_ping(int delay)
-{
-	/* remove existing ping task since we are adding new, delayed one */
-	if (global_ping_task)
-		delete_task(global_ping_task);
-
-	global_ping_task = set_task(WORK_Timed, time_now + delay, ping_nodes, NULL);
+	setup_notification();
 }
 
 /**
@@ -3776,8 +3759,6 @@ struct batch_request *preq;
 		svr_chngNodesfile = 0;
 
 	reply_ack(preq);	    /*create completely successful*/
-
-	setup_ping(2); /* adjust ping to happen in next 2 seconds */
 }
 
 /**

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -1999,6 +1999,7 @@ reset_pool_inventory_mom(mominfo_t *pmom)
 			/* this newly down/deleted Mom was the inventory Mom, */
 			/* clear her as the inventory mom in the pool */
 			ppool->vnpm_inventory_mom = NULL;
+			((mom_svrinfo_t *)(pmom->mi_data))->reporting_mom = 0;
 
 			/* see if another Mom is up to become "the one" */
 			for (i=0; i<ppool->vnpm_nummoms; ++i) {
@@ -2006,6 +2007,7 @@ reset_pool_inventory_mom(mominfo_t *pmom)
 				pxsvrmom = (mom_svrinfo_t *)pxmom->mi_data;
 				if ((pxsvrmom->msr_state & INUSE_DOWN) == 0) {
 					ppool->vnpm_inventory_mom = pxmom;
+					((mom_svrinfo_t *)(pxmom->mi_data))->reporting_mom = 1;
 					sprintf(log_buffer, msg_new_inventory_mom,
 						ppool->vnpm_vnode_pool, pxmom->mi_host);
 					log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER,
@@ -2089,6 +2091,7 @@ add_mom_to_pool(mominfo_t *pmom)
 	log_event(PBSEVENT_DEBUG3, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, log_buffer);
 	if (ppool->vnpm_inventory_mom == NULL) {
 		ppool->vnpm_inventory_mom = pmom;
+		((mom_svrinfo_t *)(pmom->mi_data))->reporting_mom = 1;
 		sprintf(log_buffer, msg_new_inventory_mom, psvrmom->msr_vnode_pool, pmom->mi_host);
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, msg_daemonname, log_buffer);
 	}
@@ -3583,10 +3586,7 @@ struct batch_request *preq;
 	}
 	have_blue_gene_nodes = rc;
 
-
-
 	reply_ack(preq);		/*request completely successful*/
-	setup_notification();
 }
 
 /**

--- a/src/server/svr_connect.c
+++ b/src/server/svr_connect.c
@@ -132,10 +132,10 @@ svr_connect(pbs_net_t hostaddr, unsigned int port, void (*func)(int), enum conn_
 
 	if ((hostaddr == pbs_server_addr) && (port == pbs_server_port_dis))
 		return (PBS_LOCAL_CONNECTION);	/* special value for local */
-
 	pmom = tfind2((unsigned long)hostaddr, port, &ipaddrs);
 	if ((pmom != NULL) && (port == pmom->mi_port)) {
-		if (((mom_svrinfo_t *)(pmom->mi_data))->msr_state & INUSE_DOWN) {
+		if ((((mom_svrinfo_t *)(pmom->mi_data))->msr_state & INUSE_DOWN)
+							&& (open_momstream(pmom) < 0)) {
 			pbs_errno = PBSE_NORELYMOM;
 			return (PBS_NET_RC_FATAL);
 		}

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -753,7 +753,8 @@ set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 	}
 
 	if (actmode == ATR_ACTION_ALTER && old_rpp_retry != rpp_retry) {
-		mcast_moms(IS_NULL);
+		struct work_task *ptask = set_task(WORK_Immed, 0, mcast_moms, NULL);
+		ptask->wt_aux = IS_NULL;
 	}
 
 	return PBSE_NONE;
@@ -791,7 +792,8 @@ set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
 	}
 
 	if (actmode == ATR_ACTION_ALTER && old_rpp_highwater != rpp_highwater) {
-		mcast_moms(IS_NULL);
+		struct work_task *ptask = set_task(WORK_Immed, 0, mcast_moms, NULL);
+		ptask->wt_aux = IS_NULL;
 	}
 
 	return PBSE_NONE;

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -732,6 +732,8 @@ action_reserve_retry_init(attribute *pattr, void *pobj, int actmode)
 int
 set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 {
+	int old_rpp_retry = rpp_retry;
+
 	if (actmode == ATR_ACTION_ALTER ||
 		actmode == ATR_ACTION_RECOV) {
 		/*
@@ -749,6 +751,11 @@ set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 				LOG_DEBUG, msg_daemonname, log_buffer);
 		}
 	}
+
+	if (actmode == ATR_ACTION_ALTER && old_rpp_retry != rpp_retry) {
+		mcast_moms(IS_NULL);
+	}
+
 	return PBSE_NONE;
 }
 
@@ -768,6 +775,8 @@ set_rpp_retry(attribute *pattr, void *pobj, int actmode)
 int
 set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
 {
+	int old_rpp_highwater = rpp_highwater;
+
 	if (actmode == ATR_ACTION_ALTER ||
 		actmode == ATR_ACTION_RECOV) {
 		/*
@@ -780,6 +789,11 @@ set_rpp_highwater(attribute *pattr, void *pobj, int actmode)
 
 		rpp_highwater = (int)pattr->at_val.at_long;
 	}
+
+	if (actmode == ATR_ACTION_ALTER && old_rpp_highwater != rpp_highwater) {
+		mcast_moms(IS_NULL);
+	}
+
 	return PBSE_NONE;
 }
 

--- a/test/fw/ptl/lib/pbs_testlib.py
+++ b/test/fw/ptl/lib/pbs_testlib.py
@@ -6797,6 +6797,9 @@ class Server(PBSService):
                             break
                     if rc == 0:
                         rc = tmprc
+
+        if id is None and obj_type == SERVER:
+            id = self.hostname
         bs_list = []
         if cmd == MGR_CMD_DELETE and oid is not None and rc == 0:
             for i in oid:

--- a/test/tests/functional/pbs_job_array.py
+++ b/test/tests/functional/pbs_job_array.py
@@ -382,7 +382,7 @@ class TestJobArray(TestFunctional):
         for _ in range(5):
             self.kill_and_restart_svr()
             self.server.expect(
-                JOB, a, subjid_1, attrop=PTL_AND, max_attempts=1)
+                JOB, a, subjid_1, attrop=PTL_AND, max_attempts=10)
 
     @skipOnCpuSet
     def test_job_array_history_duration(self):


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
Overview

There is a sequence of dialogue taking place between the server and mom when they come up. This change focuses on reversing the initial exchange to reduce the overhead on the server and making it adaptable for future scalability enhancements.

![image](https://user-images.githubusercontent.com/16252556/78898028-1c087280-7a41-11ea-8a6d-0c78eb6de5cd.png)
![image](https://user-images.githubusercontent.com/16252556/78898033-1f036300-7a41-11ea-934d-7b4c45160c8d.png)


    Initial Dialogue Exchange:

Initial dialogues exchange is a number of message exchange happens between server and mom before the server shows the node as up. The number of message exchange is reduced. Following is a sequence diagram of how mom-server interaction appeared before and now.

    IS_HELLOSVR

When the server comes up it sends IS_HELLO to all the moms in the cluster. Mom will reply back with a list of jobs and state information. This is not an efficient method as the server has to deal diligently to keep track of the moms who have not responded yet and continue sending IS_HELLO in a repeated interval. The same can be achieved by sending the first hello message from MOM without incurring overhead on the server. Mom will be initiating the dialogue with IS_HELLOSVR. The server will then check whether the receivers network resolved hostname is available in its database corresponding to a mom.

    IS_REPLYHELLO

Server will send IS_REPLYHELLO in response to IS_HELLOSVR from mom. This contains rpp values as well as the IP address of all moms for single-server mode which was being sent as part of IS_NULL and IS_CLUSTER_ADDRS.

    IS_REGISTERMOM

Mom will send IS_REGISTERMOM in response to IS_REPLYHELLO. It will contain job and vnode details. This will serve the purpose of IS_HELLO4, IS_UPDATE2 and IS_MOM_READY.

    IS_NULL

IS_NULL is a repeated heartbeat from the server to mom with rpp values. The message body contains rpp_retry and rpp_highwater.

Whenever rpp values are updated in the server it needs to update all the moms with the new set of values. But periodic ping will be removed as there are no use cases it can solve.

    IS_CLUSTERADDRS

IS_CLUSTERADDRS will send a list of addresses from server to mom which can be used for inter mom communication (More info on IS_CLUSTERADDRS). This will not be enabled for multi-server mode. Users have to use supported alternative security models as reserved ports based authentication is not secure for inter-mom communication.

    Frequency of HELLOSVR

Mom will start with quick bursts of IS_HELLOSVR followed by slower intervals. This strategy will make sure a faster connection if the server is already up and does not blow up the network with tons of requests. Mom will attempt to connect every 64 seconds in the worst case.

    Failover:

Mom will be treating two of the servers in its list with equal precedence and will be sending hello randomly to one of them. It can receive a reply back only from the active server. Mom will follow the same in the future when we have active-active failover.

    Server talking to an alien Mom:

When a server gets a job request from the scheduler which is supposed to run on a mom it does not know yet (thus alien mom), it will look into the database and find the required information. It then opens a connection stream with that mom and sends the job.

    The server attempts to talk to the mom before mom attempts to connect

This can happen due to operations such as delete_job or run_job reaching at the server before mom has reached out. Server will then attempt to open a connection via tpp and send the request to mom. Upon receiving the request mom will initiate hello exchange as well as initiating hello exchange sequence. This will succeed only if the mom is up and connected to comm.


#### Link to Design Doc
[project documentation area](https://pbspro.atlassian.net/wiki/spaces/PD/pages/1457029123/MOM+will+initiate+the+dialogue+sequence+with+server.)


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/16252556/77554290-44626f80-6e8c-11ea-8a8b-ef5f6ecf1a0b.png">




<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
