### PR TITLE
[WIP] Making Scheduler ready for MultiServer i.e. persistent connections, cycle end  notify etc.

### DIFF
--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -320,6 +320,10 @@ extern char *netaddr(struct sockaddr_in *);
 extern unsigned long crc_file(char *fname);
 extern int get_fullhostname(char *, char *, int);
 
+int send_int(int sock, int num);
+
+int recv_int(int sock, int *num);
+
 #ifdef  __cplusplus
 }
 #endif

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -232,6 +232,7 @@ struct connection {
 	void            *cn_data;         /* pointer to some data for cn_func */
 	char            cn_username[PBS_MAXUSER + 1];
 	char            cn_hostname[PBS_MAXHOSTNAME + 1];
+	int		is_sched_conn; /* used to know whether connection is from Scheduler or not */
 	char            *cn_credid;
 	char            cn_physhost[PBS_MAXHOSTNAME + 1];
 	pbs_auth_config_t   *cn_auth_config;

--- a/src/include/pbs_sched.h
+++ b/src/include/pbs_sched.h
@@ -66,6 +66,10 @@ extern "C" {
 
 #define SC_STATUS_LEN 	10
 
+#define	SCHED_CYCLE_END 0
+#define LISTEN_BACKLOG 100
+#define TCP_TIMEOUT 50000
+
 /*
  * Attributes for the server's sched object
  * Must be the same order as listed in sched_attr_def (master_sched_attr_def.xml)
@@ -114,10 +118,15 @@ typedef struct pbs_sched {
 	time_t sch_next_schedule;		/* when to next run scheduler cycle */
 	char sc_name[PBS_MAXSCHEDNAME + 1];
 	struct preempt_ordering preempt_order[PREEMPT_ORDER_MAX + 1];
+	int sched_cycle_started;
 	/* sched object's attributes  */
 	attribute sch_attr[SCHED_ATR_LAST];
 } pbs_sched;
 
+
+enum towhich_conn {
+	PRIMARY,
+	SECONDARY,};
 
 extern pbs_sched *dflt_scheduler;
 extern	pbs_list_head	svr_allscheds;
@@ -128,6 +137,11 @@ extern pbs_sched *find_sched_from_sock(int sock);
 extern pbs_sched *find_sched(char *sched_name);
 extern int validate_job_formula(attribute *pattr, void *pobject, int actmode);
 extern pbs_sched *find_sched_from_partition(char *partition);
+extern int get_sched_cmd(int sock, int *val, char **identifier);
+extern int recv_cycle_end(int sock);
+extern void initialise_svr_sock_pair();
+extern void socket_to_conn(int sock);
+extern void handle_deferred_cycle_close();
 
 #ifdef	__cplusplus
 }

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -57,6 +57,7 @@
 #define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
 #define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
 #define SCH_ATTRS_CONFIGURE 18
+#define SCH_SVR_IDENTIFIER 19
 
 
 extern int schedule(int cmd, int sd, char *runjid);

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -55,7 +55,7 @@ extern "C" {
 extern int check_num_cpus(void);
 extern int chk_hold_priv(long, int);
 extern void close_client(int);
-extern int contact_sched(int, char *, pbs_net_t, unsigned int);
+extern int contact_sched(int, char *jobid, pbs_sched *psched, enum towhich_conn which_conn);
 extern void count_node_cpus(void);
 extern int ctcpus(char *, int *);
 extern void get_jobowner(char *, char *);
@@ -131,6 +131,8 @@ extern int direct_write_requested(job *);
 extern void spool_filename(job *, char *, char *);
 extern enum failover_state are_we_primary(void);
 extern void license_more_nodes(void);
+void connect_to_scheduler(pbs_sched *psched);
+void set_sched_state(pbs_sched *psched, char *state);
 extern void reset_svr_sequence_window(void);
 extern void reply_preempt_jobs_request(int, int, struct job *);
 extern int copy_params_from_job(char *, resc_resv *);

--- a/src/lib/Libnet/net_server.c
+++ b/src/lib/Libnet/net_server.c
@@ -772,6 +772,7 @@ add_conn_priority(int sd, enum conn_type type, pbs_net_t addr, unsigned int port
 	conn->cn_authen = 0;
 	conn->cn_prio_flag = 0;
 	conn->cn_auth_config = NULL;
+	conn->is_sched_conn = 0;
 
 	num_connections++;
 
@@ -1014,7 +1015,8 @@ net_close(int but)
 		int sock = cp->cn_sock;
 		cp = GET_NEXT(cp->cn_link);
 		if(sock != but) {
-			svr_conn[sock]->cn_oncl = NULL;
+			if (svr_conn[sock]->cn_oncl != 0)
+				svr_conn[sock]->cn_oncl = NULL;
 			close_conn(sock);
 			destroy_connection(sock);
 		}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -81,6 +81,8 @@
 #include <pwd.h>
 #include <assert.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <inttypes.h>
 #ifndef WIN32
 #include <dlfcn.h>
 #include <grp.h>
@@ -2158,3 +2160,82 @@ crc_file(char *filepath)
 	return (crc(buf, sb.st_size));
 #endif
 }
+
+/**
+ * @brief
+ *  send_int - Sends an integer over the socket given
+ *
+ *  @param[in] sock	-socket descriptor
+ *  @parma[in/out] num	-pointer to the value of the integer received from the socket
+ *
+ *  @return	int
+ *  @retval	-1 	if fail/error
+ *  @retval	0	if success
+ */
+int
+send_int(int sock, int num)
+{
+        int32_t conv = htonl(num);
+        char *data = (char*)&conv;
+        int left = sizeof(conv);
+        int rc;
+        do {
+                rc = write(sock, data, left);
+                if (rc < 0) {
+                    if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                        continue;
+                    }
+                    else if (errno != EINTR) {
+                        return -1;
+                    }
+                }
+                else {
+                    data += rc;
+                    left -= rc;
+                }
+        } while (left > 0);
+
+        return 0;
+}
+
+/**
+ * @brief
+ *  recv_int - Receives an integer over the socket given
+ *
+ *  @param[in] sock	-socket descriptor
+ *  @parma[in/out] num	-pointer to the value of the integer received from the socket
+ *
+ *  @return	int
+ *  @retval	-1 	if fail/error
+ *  @retval	0	if success
+ */
+int
+recv_int(int sock, int *num)
+{
+        int32_t ret;
+        char *data = (char*)&ret;
+        int left = sizeof(ret);
+        int rc;
+        do {
+                rc = read(sock, data, left);
+                if (rc == 0)
+                        return -1;
+                if (rc < 0) { /* instead of ret */
+                    if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                            continue;
+                    }
+                    else if (errno != EINTR) {
+                        return -1;
+                    }
+                }
+                else {
+                    data += rc;
+                    left -= rc;
+                }
+        } while (left > 0);
+
+        *num = ntohl(ret);
+
+        return 0;
+}
+

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -43,7 +43,6 @@ extern "C" {
 
 #include  <limits.h>
 #include "data_types.h"
-int connector;
 
 /*
  *      schedinit - initialize conf struct and parse conf files

--- a/src/scheduler/get_4byte.c
+++ b/src/scheduler/get_4byte.c
@@ -66,8 +66,9 @@
  *
  * @param[in]	sock	-	socket endpoint to the server
  * @param[in]	val	-	pointer to the value of the scheduler command sent.
- * @param[in]	jid	-	if 'val' obtained is SCH_SCHEDULE_AJOB, then '*jid'
- *						holds the jobid of the job to be scheduled.
+ * @param[in]	identifier	-	if 'val' obtained is SCH_SCHEDULE_AJOB, then '*identifier" is  job id.
+ * 					else if 'val' obtained is SCH_SVR_IDENTIFIER then '*identifier" is index of the Server.
+ *					holds the jobid of the job to be scheduled.
  * @return	int
  * @retval	0	: for EOF,
  * @retval	+1	: for success
@@ -79,24 +80,25 @@
  */
 
 int
-get_sched_cmd(int sock, int *val, char **jid)
+get_sched_cmd(int sock, int *val, char **identifier)
 {
 	int	i;
 	int     rc = 0;
-	char	*jobid = NULL;
+	char	*id = NULL;
 
 	DIS_tcp_funcs();
 
 	i = disrsi(sock, &rc);
 	if (rc != 0)
 		goto err;
-	if (i == SCH_SCHEDULE_AJOB) {
-		jobid = disrst(sock, &rc);
+	if (i == SCH_SCHEDULE_AJOB || i == SCH_SVR_IDENTIFIER) {
+		id = disrst(sock, &rc);
 		if (rc != 0)
 			goto err;
-		*jid = jobid;
+		*identifier = id;
 	} else {
-		*jid = NULL;
+		if (identifier != NULL)
+			*identifier = NULL;
 	}
 	*val = i;
 	return 1;

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -181,3 +181,4 @@ char *logfile = NULL;
 char path_log[_POSIX_PATH_MAX];
 int dflt_sched = 0;
 int server_dyn_res_alarm = 0;
+pbs_svr_sock_pair svr_sock_pair;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -45,6 +45,12 @@ extern "C" {
 #include "data_types.h"
 #include "limits.h"
 #include "queue.h"
+
+typedef struct pbs_svr_sock_pair {
+	int ch_socket;
+	int ch_secondary_socket;
+}pbs_svr_sock_pair;
+
 /* resources to check */
 extern const struct rescheck res_to_check[];
 
@@ -105,6 +111,7 @@ extern int server_dyn_res_alarm;
  * used by sorting routine to compare with vnode's current aoe.
  */
 extern char *cmp_aoename;
+extern pbs_svr_sock_pair svr_sock_pair;
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -91,6 +91,7 @@
 #endif
 #include <sys/resource.h>
 
+#include 	<netinet/tcp.h>
 #include	"pbs_version.h"
 #include	"portability.h"
 #include	"libpbs.h"
@@ -111,10 +112,12 @@
 #include	"pbs_undolr.h"
 #include	"multi_threading.h"
 #include	"auth.h"
+#include	"pbs_sched.h"
+#include 	"misc.h"
 
-int		connector;
-int		server_sock;
-int		second_connection = -1;
+int server_sock;
+int second_connection = -1;
+fd_set master_fdset;
 
 #define		START_CLIENTS	2	/* minimum number of clients */
 #define		MAX_PORT_NUM 65535
@@ -146,6 +149,7 @@ extern int do_hard_cycle_interrupt;
 #endif /* localmod 030 */
 
 static int	engage_authentication(int);
+static int	send_cycle_end(int socket);
 
 extern char *msg_startup1;
 
@@ -282,6 +286,23 @@ server_disconnect(int connect)
 	pbs_client_thread_destroy_connect_context(connect);
 
 	return 1;
+}
+
+/**
+ *	@brief
+ *		Closes all server connections
+ *
+ */
+static void
+close_server_conns()
+{
+
+	FD_CLR(svr_sock_pair.ch_socket, &master_fdset);
+	server_disconnect(svr_sock_pair.ch_socket);
+	close(svr_sock_pair.ch_secondary_socket);
+	svr_sock_pair.ch_socket = -1;
+	svr_sock_pair.ch_secondary_socket = -1;
+
 }
 
 /**
@@ -504,33 +525,33 @@ badconn(char *msg)
  *
  * @brief
  *		Gets a scheduling command  from the server from the primary
- *		socket connection to the server. This would also attempt to
- *		get a secondary socket connection to the server, which will
- *		contain high priority scheduling commands like
- *		SCH_SCHEDULER_RESTART_CYCLE.
+ *		socket connection to the server. Also receives Server index via a scheduling command
+ *		SCH_SVR_IDENTIFIER
  *
- * @param[in]	jid	-	if command received is SCH_SCHEDULE_AJOB, then
- *			  			*jid will hold the jobid.
+ * @param[in/out]	max_sd	-	pointer to maximum socket descriptor. If new socket after
+ * 					accept call is bigger then its value is returned to the caller.
  *
  * @return	int
  * @retval	SCH_ERROR	-	if an error occured.
- * @reval	<scheduling command>	-	for example, SCH_SCHEDULE_CMD>
+ * @reval	0		-	if success
  *
  * @note
  *		The returned *jid is a malloc-ed string which must be freed by the
  *		caller.
  */
 int
-server_command(char **jid)
+accept_client(int *max_sd)
 {
-	int		new_socket;
+	int		new_socket = -1;
 	pbs_socklen_t	slen;
 	int		i;
-	int		cmd;
 	pbs_net_t	addr;
-	extern	int	get_sched_cmd(int sock, int *val, char **jobid);
-	fd_set		fdset;
-	struct timeval  timeout;
+	int		cmd;
+	char *svr_id  = NULL;
+	char *endp;
+#ifdef TCP_USER_TIMEOUT
+	int tcp_timeout = TCP_TIMEOUT;
+#endif
 
 	slen = sizeof(saddr);
 	new_socket = accept(server_sock,
@@ -540,11 +561,18 @@ server_command(char **jid)
 		return SCH_ERROR;
 	}
 
+	if (new_socket > *max_sd)
+		*max_sd = new_socket;
+
 	if (set_nodelay(new_socket) == -1) {
-		snprintf(log_buffer, sizeof(log_buffer), "cannot set nodelay on primary socket connection %d (errno=%d)\n", new_socket, errno);
+		snprintf(log_buffer, sizeof(log_buffer), "cannot set nodelay on socket connection %d (errno=%d)\n", new_socket, errno);
 		log_err(-1, __func__, log_buffer);
 		return SCH_ERROR;
 	}
+
+#ifdef TCP_USER_TIMEOUT
+	setsockopt(new_socket, IPPROTO_TCP, TCP_USER_TIMEOUT, (char*) &tcp_timeout, sizeof (tcp_timeout));
+#endif
 
 	if (ntohs(saddr.sin_port) >= IPPORT_RESERVED) {
 		badconn("non-reserved port");
@@ -563,86 +591,35 @@ server_command(char **jid)
 		return SCH_ERROR;
 	}
 
-	connector = new_socket;
-	if (engage_authentication(new_socket) == -1) {
-		CS_close_socket(new_socket);
-		close(new_socket);
-		return SCH_ERROR;
-	}
-
-	/* get_sched_cmd() located in file get_4byte.c */
-	if (get_sched_cmd(new_socket, &cmd, jid) != 1) {
+	if (get_sched_cmd(new_socket, &cmd, &svr_id) != 1) {
 		log_err(errno, __func__, "get_sched_cmd");
 		CS_close_socket(new_socket);
 		close(new_socket);
 		return SCH_ERROR;
 	}
 
-	/* Obtain the second server socket connnection		*/
-	/* this second connection is for server to communicate	*/
-	/* "super" high priority command like			*/
-	/* SCH_SCHEDULE_RESTART_CYCLE				*/
-	/* This won't cause scheduling to quit if an error      */
-	/* resulted in obtaining this second connection.	*/
-	timeout.tv_usec = 0;
-	timeout.tv_sec  = 1;
-
-	FD_ZERO(&fdset);
-	FD_SET(server_sock, &fdset);
-	if ((select(FD_SETSIZE, &fdset, NULL, NULL,
-		&timeout) != -1)  && (FD_ISSET(server_sock, &fdset))) {
-		int	cmd2;
-		char	*jid2 = NULL;
-
-		second_connection = accept(server_sock,
-			(struct sockaddr *)&saddr, &slen);
-		if (second_connection == -1) {
-			log_err(errno, __func__,
-				"warning: failed to get second_connection");
-			return cmd; /* bail out early */
-		}
-
-		if (set_nodelay(second_connection) == -1) {
-			snprintf(log_buffer, sizeof(log_buffer), "cannot set nodelay on secondary socket connection %d (errno=%d)\n", second_connection, errno);
-			log_err(-1, __func__, log_buffer);
-			return cmd;
-		}
-
-		if (ntohs(saddr.sin_port) >= IPPORT_RESERVED) {
-			badconn("second_connection: non-reserved port");
-			close(second_connection);
-			second_connection = -1;
-			return cmd;
-		}
-
-		addr = (pbs_net_t)saddr.sin_addr.s_addr;
-		for (i=0; i<numclients; i++) {
-			if (addr == okclients[i])
-				break;
-		}
-
-		if (i == numclients) {
-			badconn("second_connection: unauthorized host");
-			close(second_connection);
-			second_connection = -1;
-			return cmd;
-		}
-
-		if (get_sched_cmd(second_connection, &cmd2, &jid2) != 1) {
-			log_err(errno, __func__, "get_sched_cmd");
-			close(second_connection);
-			second_connection = -1;
-		}
-
-		if (jid2 != NULL) {
-			free(jid2);
-		}
-	} else {
-		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SERVER, LOG_DEBUG, __func__,
-			"warning: timed-out getting second_connection");
+       if (cmd == SCH_SVR_IDENTIFIER)
+		i = strtol(svr_id, &endp, 10);
+	else {
+		log_err(errno, __func__, "Invalid Server id");
+		close(new_socket);
+		return SCH_ERROR;
 	}
 
-	return cmd;
+       if (svr_id != NULL) {
+                free(svr_id);
+                svr_id = NULL;
+        }
+
+	socket_to_conn(new_socket);
+	if (engage_authentication(new_socket) == -1) {
+		CS_close_socket(new_socket);
+		close(new_socket);
+		return SCH_ERROR;
+	}
+
+	return 0;
+
 }
 
 /**
@@ -661,16 +638,16 @@ server_command(char **jid)
  *              information is closed out (freed).
  */
 static int
-engage_authentication(int sd)
+engage_authentication(int sock)
 {
 	int	ret;
 
-	if (sd < 0) {
+	if (sock <0) {
 		cs_logerr(0, "engage_authentication", "Bad arguments, unable to authenticate.");
 		return (-1);
 	}
 
-	if ((ret = CS_server_auth(sd)) == CS_SUCCESS)
+	if ((ret = CS_server_auth(sock)) == CS_SUCCESS)
 		return (0);
 
 	if (ret == CS_AUTH_CHECK_PORT) {
@@ -808,6 +785,7 @@ main(int argc, char *argv[])
 	int		t = 1;
 	pid_t		pid;
 	char		host[PBS_MAXHOSTNAME+1];
+	int 		max_sd;
 #ifndef DEBUG
 	char		*dbfile = "sched_out";
 #endif
@@ -817,12 +795,13 @@ main(int argc, char *argv[])
 	extern	int	optind, opterr;
 	char	       *runjobid = NULL;
 	extern	int	tpp_fd;
-	fd_set		fdset;
+	fd_set		read_fdset;
 	int		opt_no_restart = 0;
 #ifdef NAS /* localmod 031 */
 	time_t		now;
 #endif /* localmod 031 */
 	int		stalone = 0;
+	int		schedinit();
 #ifdef _POSIX_MEMLOCK
 	int		do_mlockall = 0;
 #endif	/* _POSIX_MEMLOCK */
@@ -1099,6 +1078,14 @@ main(int argc, char *argv[])
 		die(0);
 	}
 
+#ifdef SO_RESUSEPORT
+	if (setsockopt(server_sock, SOL_SOCKET, SO_REUSEPORT,
+		(char *)&t, sizeof(t)) == -1) {
+		log_err(errno, __func__, "setsockopt");
+		die(0);
+	}
+#endif
+
 	saddr.sin_family = AF_INET;
 	saddr.sin_port = htons(sched_port);
 	saddr.sin_addr.s_addr = INADDR_ANY;
@@ -1127,7 +1114,7 @@ main(int argc, char *argv[])
 		}
 	}
 
-	if (listen(server_sock, 5) < 0) {
+	if (listen(server_sock, LISTEN_BACKLOG) < 0) {
 		log_err(errno, __func__, "listen");
 		die(0);
 	}
@@ -1323,18 +1310,26 @@ main(int argc, char *argv[])
 
 	tpp_poll(); /* to clear off the read notification */
 
+	initialise_svr_sock_pair();
+
 	/* Initialize cleanup lock */
 	if (init_mutex_attr_recursive(&attr) == 0)
 		die(0);
 
 	pthread_mutex_init(&cleanup_lock, &attr);
 
-	FD_ZERO(&fdset);
-	for (go=1; go;) {
-		int	cmd;
+	FD_ZERO(&master_fdset);
+	FD_SET(server_sock, &master_fdset);
+	max_sd = server_sock;
 
-		FD_SET(server_sock, &fdset);
-		if (select(FD_SETSIZE, &fdset, NULL, NULL, NULL) == -1) {
+	for (go=1; go;) {
+		int cmd;
+		int sock_to_check;
+
+		FD_ZERO(&read_fdset);
+		memcpy(&read_fdset, &master_fdset, sizeof(master_fdset));
+
+		if (select(max_sd + 1, &read_fdset, NULL, NULL, NULL) < 0) {
 			if (errno != EINTR) {
 				log_err(errno, __func__, "select");
 				die(0);
@@ -1346,59 +1341,80 @@ main(int argc, char *argv[])
 		if (sigusr1_flag)
 			undolr();
 #endif
-		if (!FD_ISSET(server_sock, &fdset))
-			continue;
 
-		/* connector is set in server_connect() */
-		cmd = server_command(&runjobid);
+		if (FD_ISSET(server_sock, &read_fdset)) {
+			if (accept_client(&max_sd) != 0)
+				die(0);
+		}
 
-		if (connector >= 0) {
-			if (update_svr) {
-				/* update sched object attributes on server */
-				update_svr_schedobj(connector, cmd, alarm_time);
-				update_svr = 0;
-			}
+		sock_to_check = svr_sock_pair.ch_socket;
 
-			if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
-				log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
+		if ((sock_to_check != -1) && FD_ISSET(sock_to_check, &read_fdset)) {
+			int ret;
+			ret = get_sched_cmd(sock_to_check, &cmd, &runjobid);
+			if (ret != 1) {
+				close_server_conns();
+				log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+						"get_sched_cmd failed, errno=%d in function %s. "
+						"One  of the reasons includes server might have shutdown", errno, __func__);
+			} else {
+				if (sock_to_check >= 0) {
+					if (update_svr) {
+						/* update sched object attributes on server */
+						if (update_svr_schedobj(sock_to_check, cmd, alarm_time) == 0) {
+							close_server_conns();
+						}
+						update_svr = 0;
+					}
+
+				if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
+					log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
 
 			/* Keep track of time to use in SIGSEGV handler */
 #ifdef NAS /* localmod 031 */
-			now = time(NULL);
-			if (!opt_no_restart)
-				segv_last_time = now;
-			{
-				strftime(log_buffer, sizeof(log_buffer),
-					"%Y-%m-%d %H:%M:%S", localtime(&now));
-				printf("%s Scheduler received command %d\n", log_buffer, cmd);
-			}
+				now = time(NULL);
+				if (!opt_no_restart)
+					segv_last_time = now;
+				{
+					strftime(log_buffer, sizeof(log_buffer),
+						"%Y-%m-%d %H:%M:%S", localtime(&now));
+					printf("%s Scheduler received command %d\n", log_buffer, cmd);
+				}
 #else
-			if (!opt_no_restart)
-				segv_last_time = time(NULL);
+				if (!opt_no_restart)
+					segv_last_time = time(NULL);
 
-			DBPRT(("Scheduler received command %d\n", cmd));
+				DBPRT(("Scheduler received command %d\n", cmd));
 #endif /* localmod 031 */
 
-			if (schedule(cmd, connector, runjobid)) /* magic happens here */ {
-				go = 0;
-			}
-			if (second_connection != -1) {
-				close(second_connection);
-				second_connection = -1;
-			}
 
-			if (server_disconnect(connector))
-				connector = -1;
+				second_connection = svr_sock_pair.ch_secondary_socket;
 
-			if (runjobid != NULL) {
-				free(runjobid);
-				runjobid = NULL;
+				if (schedule(cmd, sock_to_check, runjobid))  /* magic happens here */ {
+					go = 0;
+					close_server_conns();
+				}
+
+				if (send_cycle_end(second_connection)) {
+					go = 0;
+					close_server_conns();
+				}
+
+				if (runjobid != NULL) {
+					free(runjobid);
+					runjobid = NULL;
+				}
+
+				if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
+					log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
+				}
 			}
-
-			if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
-				log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 		}
 	}
+	if (svr_sock_pair.ch_secondary_socket != -1) {
+		close(svr_sock_pair.ch_secondary_socket);
+	}
+	server_disconnect(svr_sock_pair.ch_socket);
 	schedexit();
 
 	sprintf(log_buffer, "%s normal finish pid %ld", argv[0], (long)pid);
@@ -1408,4 +1424,63 @@ main(int argc, char *argv[])
 	(void)close(server_sock);
 	unload_auths();
 	exit(0);
+}
+
+/**
+ * @brief
+ *  	initialise_svr_conn - Initializes server connection pair.
+ *
+ * @return	void
+ *
+ */
+void
+initialise_svr_sock_pair()
+{
+	svr_sock_pair.ch_socket= -1;
+	svr_sock_pair.ch_secondary_socket = -1;
+}
+
+/**
+ * @brief
+ *  	socket_to_conn - Stores the socket in the server connection pair.
+ *
+ * @return	void
+ *
+ */
+void
+socket_to_conn(int sock)
+{
+	if (svr_sock_pair.ch_socket != -1) {
+		svr_sock_pair.ch_secondary_socket = sock;
+	} else {
+		svr_sock_pair.ch_socket = sock;
+		FD_SET(sock, &master_fdset);
+	}
+}
+
+/**
+ *
+ * @brief
+ *		Sends end of cycle indication to the Server
+ *
+ * @param[in]	socket	-	socet on which to send to the notification
+ *
+ *
+ * @return	int
+ * @retval	-1	-	if an error occured.
+ * @reval	0	-	if success
+ *
+ * @note
+ *		The returned *jid is a malloc-ed string which must be freed by the
+ *		caller.
+ */
+static int
+send_cycle_end(int socket)
+{
+	int rc;
+	rc = send_int(second_connection, SCHED_CYCLE_END);
+	if (rc == -1)
+		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+			"Not able to send end of cycle, errno = %d", errno);
+	return rc;
 }

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -148,7 +148,7 @@ extern int chk_save_file(char *filename);
 extern int chk_and_update_db_svrhost();
 #endif /* localmod 005 */
 
-extern int put_sched_cmd(int sock, int cmd, char *jobid);
+extern int put_sched_cmd(int sock, int cmd, char *identifier);
 extern void setup_ping(int delay);
 
 /* External data items */
@@ -1577,7 +1577,7 @@ try_db_again:
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long) {
 			/* Bring up scheduler here */
 			pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_secondary);
-			if (contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port) < 0) {
+			if (contact_sched(SCH_SCHEDULE_NULL, NULL, dflt_scheduler, PRIMARY) < 0) {
 				char **workenv;
 				char schedcmd[MAXPATHLEN + 1];
 				/* save the current, "safe", environment.
@@ -1649,6 +1649,10 @@ try_db_again:
 	if ((pc=strchr(svr_interp_data.local_host_name, '.')) != NULL)
 		*pc = '\0';
 
+	if (server_init_type != RECOV_CREATE) {
+		connect_to_scheduler(dflt_scheduler);
+	}
+
 	if (pbs_python_ext_start_interpreter(&svr_interp_data) != 0) {
 		log_err(-1, msg_daemonname, "Failed to start Python interpreter");
 		stop_db();
@@ -1671,13 +1675,13 @@ try_db_again:
 	}
 	process_hooks(periodic_req, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
 
-	/*
-	 * Make the scheduler (re)-read the configuration
-	 * and fairshare usage.
-	 */
-	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
-	(void)contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port);
-
+	if (server_init_type != RECOV_CREATE) {
+		/*
+		 * Make the scheduler (re)-read the configuration
+		 * and fairshare usage.
+		 */
+		(void)contact_sched(SCH_CONFIGURE, NULL,  dflt_scheduler, PRIMARY);
+	}
 
 	/*
 	 * main loop of server
@@ -1721,7 +1725,10 @@ try_db_again:
 			}
 			for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
 				/* if time or event says to run scheduler, do it */
-
+				if (psched->scheduler_sock == -1 && psched->scheduler_sock2 == -1) {
+					connect_to_scheduler(psched);
+					continue;
+				}
 				/* if we have a high prio sched command, send it 1st */
 				if (psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
 					schedule_high(psched);
@@ -1732,8 +1739,8 @@ try_db_again:
 					/* cycle */
 					/* NOTE: both primary and secondary scheduler */
 					/* connect must have been setup to be valid */
-					if ((psched->scheduler_sock2 != -1) &&
-						(psched->scheduler_sock != -1)) {
+					if ((psched->scheduler_sock2 != -1) && (psched->scheduler_sock != -1) &&
+							psched->sched_cycle_started == 1) {
 
 						if (put_sched_cmd(psched->scheduler_sock2,
 								psched->svr_do_schedule, NULL) == 0) {
@@ -1857,7 +1864,7 @@ try_db_again:
 	/* if brought up the Secondary Scheduler, take it down */
 
 	if (brought_up_alt_sched == 1)
-		(void)contact_sched(SCH_QUIT, NULL, pbs_scheduler_addr, pbs_scheduler_port);
+		(void)contact_sched(SCH_QUIT, NULL,  dflt_scheduler, PRIMARY);
 
 	/* if Moms are to to down as well, tell them */
 

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -109,6 +109,7 @@
 #include "svrfunc.h"
 #include "pbs_sched.h"
 #include "auth.h"
+#include "libutil.h"
 
 /* global data items */
 
@@ -277,6 +278,14 @@ process_request(int sfds)
 		CLOSESOCKET(sfds);
 		return;
 	}
+
+#ifndef PBS_MOM
+	if (conn->is_sched_conn) {
+		if (recv_cycle_end(sfds) == -1)
+			close_conn(sfds);
+		return;
+	}
+#endif
 
 	if ((request = alloc_br(0)) == NULL) {
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_REQUEST, LOG_ERR, __func__, "Unable to allocate request structure");

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -339,7 +339,7 @@ req_runjob(struct batch_request *preq)
 	}
 
 #ifndef NAS /* localmod 133 */
-	if ((psched->scheduler_sock != -1) && was_job_alteredmoved(parent)) {
+	if ((psched->sched_cycle_started != -1) && was_job_alteredmoved(parent)) {
 		int index = find_attr(sched_attr_def, ATTR_throughput_mode, SCHED_ATR_LAST);
 		/* do not blacklist altered/moved jobs when throughput_mode is enabled */
 		if ((index == -1) ||

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -271,7 +271,7 @@ req_shutdown(struct batch_request *preq)
 		(void)failover_send_shutdown(FAILOVER_SecdShutdown);
 
 	if (shutdown_who & SHUT_WHO_SCHED)
-		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler->pbs_scheduler_addr, dflt_scheduler->pbs_scheduler_port);	/* tell scheduler to quit */
+		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler, PRIMARY);	/* tell scheduler to quit */
 
 	if (shutdown_who & SHUT_WHO_SECDONLY) {
 		reply_ack(preq);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -68,6 +68,8 @@
 #include "pbs_sched.h"
 #include "queue.h"
 #include "pbs_share.h"
+#include "pbs_sched.h"
+#include <netinet/tcp.h>
 
 
 /* Global Data */
@@ -91,6 +93,7 @@ int scheduler_jobs_stat = 0;	/* set to 1 once scheduler queried jobs in a cycle*
 extern int svr_unsent_qrun_req;
 #define PRIORITY_CONNECTION 1
 
+
 /**
  * @brief
  * 		am_jobs - array of pointers to jobs which were moved or which had certain
@@ -109,7 +112,7 @@ static struct   am_jobs {
 /* Functions private to this file */
 static void scheduler_close(int);
 
-#define SCHEDULER_ALARM_TIME 20
+#define SCHEDULER_ALARM_TIME 30
 /**
  * @brief
  * 		catchalrm	-	put a timeout alarm in case of timeout occurs when contacting the scheduler.
@@ -130,6 +133,7 @@ catchalrm(int sig)
  * @param[in]	sock	-	communication endpoint
  * @param[in]	cmd	-	the command to send
  * @param[in]	jobid	-	the jobid to send if 'cmd' is SCH_SCHEDULE_AJOB
+ * 			-	the index of the server if 'cmd' is SCH_SVR_IDENTIFIER
  *
  * @return	int
  * @retval	0	for success
@@ -137,7 +141,7 @@ catchalrm(int sig)
  */
 
 int
-put_sched_cmd(int sock, int cmd, char *jobid)
+put_sched_cmd(int sock, int cmd, char *identifier)
 {
 	int   ret;
 
@@ -145,8 +149,8 @@ put_sched_cmd(int sock, int cmd, char *jobid)
 	if ((ret = diswsi(sock, cmd)) != DIS_SUCCESS)
 		goto err;
 
-	if (cmd == SCH_SCHEDULE_AJOB) {
-		if ((ret = (diswst(sock, jobid))) != DIS_SUCCESS)
+	if (cmd == SCH_SCHEDULE_AJOB || cmd == SCH_SVR_IDENTIFIER) {
+		if ((ret = (diswst(sock, identifier))) != DIS_SUCCESS)
 			goto err;
 	}
 
@@ -267,63 +271,84 @@ find_sched_from_sock(int sock)
  */
 
 int
-contact_sched(int cmd, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int pbs_scheduler_port)
+contact_sched(int cmd, char *jobid, pbs_sched *psched, enum towhich_conn which_conn)
 {
-	int sock;
+	int sock = -1;
 	conn_t *conn;
-	struct sigaction act, oact;
+#ifdef TCP_USER_TIMEOUT
+	int tcp_timeout = TCP_TIMEOUT;
+#endif
 
 	if ((cmd == SCH_SCHEDULE_AJOB) && (jobid == NULL))
 		return -1;	/* need a jobid */
 
-	/* connect to the Scheduler */
-	/* put a timeout alarm around the connect */
+	if (((which_conn == PRIMARY )&& (psched->scheduler_sock == -1) )||
+			((which_conn == SECONDARY) && (psched->scheduler_sock2 == -1))) {
+		/* Under win32, this function does a timeout wait on the non-blocking socket */
+		sock = client_to_svr(psched->pbs_scheduler_addr, psched->pbs_scheduler_port, 1); /* scheduler connection still uses resv-ports */
+		if (pbs_errno == PBSE_NOLOOPBACKIF)
+			log_err(PBSE_NOLOOPBACKIF, "client_to_svr" , msg_noloopbackif);
 
-	sigemptyset(&act.sa_mask);
-	act.sa_flags = 0;
-	act.sa_handler = catchalrm;
-	if (sigaction(SIGALRM, &act, &oact) == -1)
-		return (PBS_NET_RC_RETRY);
-	alarm(SCHEDULER_ALARM_TIME);
+		if (sock < 0) {
+			log_err(errno, __func__, msg_sched_nocall);
+			return (-1);
+		}
 
-	/* This function does a timeout wait on the non-blocking socket */
-	sock = client_to_svr(pbs_scheduler_addr, pbs_scheduler_port, B_RESERVED); /* scheduler connection still uses resv-ports */
-	if (pbs_errno == PBSE_NOLOOPBACKIF)
-		log_err(PBSE_NOLOOPBACKIF, "client_to_svr" , msg_noloopbackif);
+#ifdef TCP_USER_TIMEOUT
+		setsockopt(sock, IPPROTO_TCP, TCP_USER_TIMEOUT, (char*) &tcp_timeout, sizeof (tcp_timeout));
+#endif
 
-	alarm(0);
 
-	(void)sigaction(SIGALRM, &oact, NULL);	/* reset handler for SIGALRM */
-	if (sock < 0) {
-		log_err(errno, __func__, msg_sched_nocall);
-		return (-1);
+		conn = add_conn_priority(sock, FromClientDIS, psched->pbs_scheduler_addr,
+		psched->pbs_scheduler_port, NULL, process_request, PRIORITY_CONNECTION);
+
+		if (!conn) {
+			log_err(errno, __func__, "could not find sock in connection table");
+			return (-1);
+		}
+		conn->cn_authen |= PBS_NET_CONN_TO_SCHED | PBS_NET_CONN_FROM_PRIVIL | PBS_NET_CONN_AUTHENTICATED;
+
+		if (which_conn == SECONDARY)
+			conn->is_sched_conn = 1;
+
+		strcpy(conn->cn_username, PBS_SCHED_DAEMON_NAME);
+		conn->cn_credid = strdup(PBS_SCHED_DAEMON_NAME);
+		if (conn->cn_credid == NULL) {
+			log_err(errno, __func__, "Out of memory!");
+			return (-1);
+		}
+		conn->cn_auth_config = make_auth_config(AUTH_RESVPORT_NAME, "", 0, (void *)log_event);
+		if (conn->cn_auth_config == NULL) {
+			log_err(errno, __func__, "Out of memory!");
+			return -1;
+		}
+		DIS_tcp_funcs();
+		transport_chan_set_ctx_status(sock, AUTH_STATUS_CTX_READY, FOR_AUTH);
+		net_add_close_func(sock, scheduler_close);
+
+		if (set_nodelay(sock) == -1) {
+			snprintf(log_buffer, sizeof(log_buffer), "cannot set nodelay on connection %d (errno=%d)\n", sock, errno);
+			log_err(-1, __func__, log_buffer);
+			return (-1);
+		}
+
+		if (put_sched_cmd(sock, SCH_SVR_IDENTIFIER, "0") < 0) {
+			close_conn(sock);
+			return (-1);
+		}
+
+		if (which_conn == PRIMARY)
+			psched->scheduler_sock = sock;
+		else
+			psched->scheduler_sock2 = sock;
+		return sock;
 	}
-	conn = add_conn_priority(sock, FromClientDIS, pbs_scheduler_addr,
-		pbs_scheduler_port, NULL, process_request, PRIORITY_CONNECTION);
-	if (!conn) {
-		log_err(errno, __func__, "could not find sock in connection table");
-		return (-1);
-	}
-	conn->cn_authen |= PBS_NET_CONN_TO_SCHED | PBS_NET_CONN_FROM_PRIVIL | PBS_NET_CONN_AUTHENTICATED;
-	strcpy(conn->cn_username, PBS_SCHED_DAEMON_NAME);
-	conn->cn_credid = strdup(PBS_SCHED_DAEMON_NAME);
-	if (conn->cn_credid == NULL) {
-		log_err(errno, __func__, "Out of memory!");
-		return (-1);
-	}
-	conn->cn_auth_config = make_auth_config(AUTH_RESVPORT_NAME, "", 0, (void *)log_event);
-	if (conn->cn_auth_config == NULL) {
-		log_err(errno, __func__, "Out of memory!");
-		return -1;
-	}
-	DIS_tcp_funcs();
-	transport_chan_set_ctx_status(sock, AUTH_STATUS_CTX_READY, FOR_AUTH);
-	net_add_close_func(sock, scheduler_close);
 
-	if (set_nodelay(sock) == -1) {
-		snprintf(log_buffer, sizeof(log_buffer), "cannot set nodelay on connection %d (errno=%d)\n", sock, errno);
-		log_err(-1, __func__, log_buffer);
-		return (-1);
+	if (sock == -1) {
+		if ((which_conn == PRIMARY) && (psched->scheduler_sock != -1))
+			sock = psched->scheduler_sock;
+		if ((which_conn == SECONDARY) && (psched->scheduler_sock2 != -1))
+			sock = psched->scheduler_sock2;
 	}
 
 	/* send command to Scheduler */
@@ -332,6 +357,8 @@ contact_sched(int cmd, char *jobid, pbs_net_t pbs_scheduler_addr, unsigned int p
 		close_conn(sock);
 		return (-1);
 	}
+	psched->sched_cycle_started = 1;
+
 	(void)sprintf(log_buffer, msg_sched_called, cmd);
 	log_event(PBSEVENT_SCHED, PBS_EVENTCLASS_SERVER, LOG_INFO,
 		server_name, log_buffer);
@@ -355,23 +382,17 @@ schedule_high(pbs_sched *psched)
 	if (psched == NULL)
 		return -1;
 
-	if (psched->scheduler_sock == -1) {
-		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
-			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
+	if (psched->sched_cycle_started == 0) {
+		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched, PRIMARY)) < 0) {
+			set_sched_state(psched, SC_DOWN);
 			return (-1);
 		}
-		set_sched_sock(s, psched);
-		if (psched->scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
-				psched->scheduler_sock2 = s;
-		}
 		psched->svr_do_sched_high = SCH_SCHEDULE_NULL;
+		set_sched_state(psched, SC_SCHEDULING);
 		return 0;
+	} else {
+		return 1;
 	}
-
-	set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
-
-	return 1;
 }
 
 /**
@@ -407,8 +428,7 @@ schedule_jobs(pbs_sched *psched)
 	else
 		cmd = psched->svr_do_schedule;
 
-	if (psched->scheduler_sock == -1) {
-
+	if (psched->sched_cycle_started == 0) {
 		/* are there any qrun requests from manager/operator */
 		/* which haven't been sent,  they take priority      */
 		pdefr = (struct deferred_request *)GET_NEXT(svr_deferred_req);
@@ -433,20 +453,15 @@ schedule_jobs(pbs_sched *psched)
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
 
-		if ((s = contact_sched(cmd, jid, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) < 0) {
-			set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_DOWN);
+		if ((s = contact_sched(cmd, jid,  psched, PRIMARY)) < 0) {
+			set_sched_state(psched, SC_DOWN);
 			return (-1);
 		}
 		else if (pdefr != NULL)
 			pdefr->dr_sent = 1;   /* mark entry as sent to sched */
-		set_sched_sock(s, psched);
-		if (psched->scheduler_sock2 == -1) {
-			if ((s = contact_sched(SCH_SCHEDULE_NULL, NULL, psched->pbs_scheduler_addr, psched->pbs_scheduler_port)) >= 0)
-				psched->scheduler_sock2 = s;
-		}
 		psched->svr_do_schedule = SCH_SCHEDULE_NULL;
 
-		set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_SCHEDULING);
+		set_sched_state(psched, SC_SCHEDULING);
 
 		first_time = 0;
 
@@ -462,10 +477,11 @@ schedule_jobs(pbs_sched *psched)
 			}
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
+	} else {
+		return 1;
+	}
 
-		return (0);
-	} else
-		return (1);	/* scheduler was busy */
+	return (0);
 
 }
 
@@ -489,7 +505,6 @@ schedule_jobs(pbs_sched *psched)
 static void
 scheduler_close(int sock)
 {
-	struct deferred_request *pdefr;
 	pbs_sched *psched;
 
 	psched = find_sched_from_sock(sock);
@@ -497,45 +512,23 @@ scheduler_close(int sock)
 	if (psched == NULL)
 		return;
 
-	set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]), &sched_attr_def[(int) SCHED_ATR_sched_state], SC_IDLE);
+	psched->sched_cycle_started = 0;
+
 
 	if ((sock != -1) && (sock == psched->scheduler_sock2)) {
 		psched->scheduler_sock2 = -1;
 		return;	/* nothing to check if scheduler_sock2 */
 	}
 
-	set_sched_sock(-1, psched);
+	psched->scheduler_sock = -1;
+	set_sched_state(psched, SC_IDLE);
 
 	/* clear list of jobs which were altered/modified during cycle */
 	am_jobs.am_used = 0;
 	scheduler_jobs_stat = 0;
 
-	/**
-	 *	If a deferred (from qrun) had been sent to the Scheduler and is still
-	 *	there, then the Scheduler must have closed the connection without
-	 *	dealing with the job.  Tell qrun it failed if the qrun connection
-	 *	is still there.
-	 *      If any qrun request is pending in the deffered list, set svr_unsent_qrun_req so
-	 * 	they are sent when the Scheduler completes this cycle
-	 */
-	pdefr = (struct deferred_request *)GET_NEXT(svr_deferred_req);
-	while (pdefr) {
-		struct deferred_request *next_pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
-		if (pdefr->dr_sent != 0) {
-			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB,
-				LOG_NOTICE, pdefr->dr_id,
-				"deferred qrun request to scheduler failed");
-			if (pdefr->dr_preq != NULL)
-				req_reject(PBSE_INTERNAL, 0, pdefr->dr_preq);
-			/* unlink and free the deferred request entry */
-			delete_link(&pdefr->dr_link);
-			free(pdefr);
-		}
-		else if((pdefr->dr_sent == 0) && (svr_unsent_qrun_req == 0)) {
-			svr_unsent_qrun_req = 1;
-		}
-		pdefr = next_pdefr;
-	}
+	handle_deferred_cycle_close();
+
 }
 
 /**
@@ -620,3 +613,123 @@ set_scheduler_flag(int flag, pbs_sched *psched)
 	}
 
 }
+
+/**
+ * @brief
+ * 		Connects to the Scheduler requested.
+ *
+ * @param[in]	pjob	-	pointer to scheduler object
+ *
+ * @return	void
+ */
+void
+connect_to_scheduler(pbs_sched *psched)
+{
+	int sock;
+	sock = contact_sched(SCH_SCHEDULE_NULL, NULL, psched, PRIMARY);
+	if (sock != -1) {
+		if (contact_sched(SCH_SCHEDULE_NULL, NULL, psched, SECONDARY) == -1) {
+			close_conn(sock);
+		} else {
+			set_sched_state(psched, SC_IDLE);
+		}
+
+	}
+}
+
+/**
+ * @brief
+ * 		Connects to the Scheduler requested.
+ *
+ * @param[in]	psched	-	pointer to scheduler object
+ * @param[in] state	-	state of the scheduler
+ *
+ * @return	void
+ */
+void
+set_sched_state(pbs_sched *psched, char *state)
+{
+	 set_attr_svr(&(psched->sch_attr[(int) SCHED_ATR_sched_state]),
+			 &sched_attr_def[(int) SCHED_ATR_sched_state], state);
+	 server.sv_attr[(int)SRV_ATR_State].at_flags |= ATR_VFLAG_MODCACHE;
+}
+
+/**
+ * @brief
+ * 		recv_cycle_end - Receives end of cycle notification from the corresponding Scheduler
+ *
+ * @param[in]	sock	-	socket to read
+ *
+ * @return	int
+ * @retval	0	: on success
+ * @retval	-1	: on error
+ */
+int
+recv_cycle_end(int sock)
+{
+	pbs_sched *psched;
+	int rc;
+
+	for (psched = (pbs_sched*) GET_NEXT(svr_allscheds); psched; psched = (pbs_sched*) GET_NEXT(psched->sc_link)) {
+		if (psched->scheduler_sock2 == sock) {
+			rc = recv_int(sock, &(psched->sched_cycle_started));
+			if (rc == -1) {
+				psched->scheduler_sock2 = -1;
+				psched->sched_cycle_started = 0;
+				set_sched_state(psched, SC_DOWN);
+			} else
+				set_sched_state(psched, SC_IDLE);
+
+			/* clear list of jobs which were altered/modified during cycle */
+			am_jobs.am_used = 0;
+			scheduler_jobs_stat = 0;
+			handle_deferred_cycle_close();
+
+			return rc;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief
+ * 		handle_deferred_cycle_close - Handles deferred requests during scheduling cycle closure
+ *
+ * @return	void
+ */
+void
+handle_deferred_cycle_close()
+{
+	struct deferred_request *pdefr;
+
+	/*
+	 *	If a deferred (from qrun) had been sent to the Scheduler and is still
+	 *	there, then the Scheduler must have closed the connection without
+	 *	dealing with the job.  Tell qrun it failed if the qrun connection
+	 *	is still there.
+	 *      If any qrun request is pending in the deffered list, set svr_unsent_qrun_req so
+	 * 	they are sent when the Scheduler completes this cycle
+	 */
+	pdefr = (struct deferred_request *)GET_NEXT(svr_deferred_req);
+	while (pdefr) {
+		struct deferred_request *next_pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
+		if (pdefr->dr_sent != 0) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_JOB,
+				LOG_NOTICE, pdefr->dr_id,
+				"deferred qrun request to scheduler failed");
+			if (pdefr->dr_preq != NULL)
+				req_reject(PBSE_INTERNAL, 0, pdefr->dr_preq);
+			/* unlink and free the deferred request entry */
+			delete_link(&pdefr->dr_link);
+			free(pdefr);
+		}
+		else if((pdefr->dr_sent == 0) && (svr_unsent_qrun_req == 0)) {
+			svr_unsent_qrun_req = 1;
+		}
+		pdefr = next_pdefr;
+	}
+
+}
+
+

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -619,7 +619,7 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 	if (pobj == dflt_scheduler)
 		return PBSE_SCHED_OP_NOT_PERMITTED;
 
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode != ATR_ACTION_RECOV) {
 		psched = (pbs_sched *) GET_NEXT(svr_allscheds);
 		while (psched != NULL) {
 			if (psched->sch_attr[SCHED_ATR_sched_priv].at_flags & ATR_VFLAG_SET) {
@@ -632,9 +632,9 @@ action_sched_priv(attribute *pattr, void *pobj, int actmode)
 			}
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
-	}
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER)
 		set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+	}
+
 	return PBSE_NONE;
 }
 
@@ -660,7 +660,7 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 	if (pobj == dflt_scheduler)
 		return PBSE_SCHED_OP_NOT_PERMITTED;
 
-	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
+	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode != ATR_ACTION_RECOV) {
 		psched = (pbs_sched*) GET_NEXT(svr_allscheds);
 		while (psched != NULL) {
 			if (psched->sch_attr[SCHED_ATR_sched_log].at_flags & ATR_VFLAG_SET) {
@@ -673,12 +673,12 @@ action_sched_log(attribute *pattr, void *pobj, int actmode)
 			}
 			psched = (pbs_sched*) GET_NEXT(psched->sc_link);
 		}
-	}
-	if (actmode != ATR_ACTION_RECOV)
 		set_scheduler_flag(SCH_ATTRS_CONFIGURE, psched);
+
+	}
+
 	return PBSE_NONE;
 }
-
 /**
  * @brief action function for 'log_events' sched attribute
  *

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -318,7 +318,7 @@ encode_svrstate(attribute *pattr, pbs_list_head *phead, char *atname, char *rsna
 	if (pattr->at_val.at_long == SV_STATE_RUN) {
 		if (server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long == 0)
 			psname = svr_idle;
-		else if (dflt_scheduler->scheduler_sock != -1)
+		else if (dflt_scheduler && dflt_scheduler->sched_cycle_started == 1)
 			psname = svr_sched;
 	}
 

--- a/test/tests/functional/pbs_multi_sched.py
+++ b/test/tests/functional/pbs_multi_sched.py
@@ -2033,8 +2033,8 @@ e.accept()
             self.server.expect(RESV, attr, rid)
             partition = self.server.status(RESV, 'partition', id=rid)
             if (partition[0]['partition'] == 'P1'):
-                    old_end_time = a['reserve_end']
-                    modify_resv = rid
+                old_end_time = a['reserve_end']
+                modify_resv = rid
         # Modify the endtime of reservation confirmed on partition P1 and
         # make sure the node solution is correct.
         end_time = old_end_time + 60


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Make Scheduler ready for MultiServer.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Following is the motivation for this RFE.

We are sharding large scale objects like jobs in Multi-Server world for better scalability. Scheduler might choose a different server instance/s to run the jobs than the one who has kicked off the cycle.  Scheduler closing all Server connections at the end of the cycle causes lot of performance issues. Instead if we have persistent connections Scheduler/s talks to the Server/s directly on these connections.

In order to achieve the above following are the high level work-items that are done.

- Modified the IO multiplexing code at the scheduler so as to listen to multiple clients in this case multiple servers.
- Maintain Server-Scheduler connections persistent
- As the connections are persistent, when Scheduler finishes its cycle it needs to have a mechanism through which it can tell the Server that scheduling cycle is finished.  This can be easily achieved by just writing an integer on secondary connection socket which acts as an end of cycle indication to Server/s.
- Each Server can mark a flag when it kicks off a scheduling cycle and clears this flag when it receives end of cycle indication from Scheduler. 
- In case of multiple PBS Servers,  each Server should distinguish itself from others to Scheduler. So each Server sends its identity to the Scheduler so that it stores all its data in the corresponding data structure and acts accordingly. To accomplish this Server sends its identity(id) via a new scheduling command SCH_SVR_IDENTIFIER when it tries to connect to the Scheduler for the first time. From there on words Server does not need to send its id since the connection is persistent. This change comes in handy when Multi-Server starts functioning when libshard integration etc. are done.
- Server should receive end of cycle notification in process_request if the request is from Scheduler. As we have to check every time whether the request is from Scheduler or not and then proceed forward makes a O(n) operation especially in case of Multiple Schedulers. Optimised this operation to O(1) by introducing is_sched_conn in connection structure and the corresponding code changes.
- Re-factor Server side code changes so as to work with the above changes.
- Introduced TCP_USER_TIMEOUT and SO_REUSEPORT. These changes are very much needed.

Also I have done the following miscellaneous changes which are related to this RFE.
- At times Server can crash if there is no call back registered when a connection gets closed.
-  No need to validate certain Scheduler attributes during recovery from db.


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
Following is the design document.
https://pbspro.atlassian.net/wiki/spaces/PD/pages/1518108673/Scheduler+Maintaining+Persistent+Server+Connections
#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
Lot of testing is done to make sure all test cases work fine. Following are the details.
![image](https://user-images.githubusercontent.com/17923736/78539941-fe54c680-7810-11ea-981a-b4dc3cd1f02d.png)

Jenkins Build report:
![image](https://user-images.githubusercontent.com/17923736/78539975-0dd40f80-7811-11ea-87b9-9d2386976770.png)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
