### PR TITLE
Fix for the next Jobid seq when server shutdown gracefully

### DIFF
--- a/src/include/server.h
+++ b/src/include/server.h
@@ -177,6 +177,7 @@ extern attribute_def svr_attr_def[];
 /* for trillion job id */
 extern long long svr_max_job_sequence_id;
 extern long long svr_jobidnumber;
+extern long long next_svr_sequence_id;
 /* for history jobs*/
 extern long svr_history_enable;
 extern long svr_history_duration;

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -136,7 +136,7 @@ svr_shutdown(int type)
       /* Saving server jobid number to the database as server is going to shutdown.
 	 * Once server will come up then it will start jobid/resvid from this number onwards.
 	 */
-	server.sv_qs.sv_jobidnumber = svr_jobidnumber;
+	server.sv_qs.sv_jobidnumber = next_svr_sequence_id;
 	state = &server.sv_attr[(int)SRV_ATR_State].at_val.at_long;
 	(void)strcpy(log_buffer, msg_shutdown_start);
 

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -382,9 +382,9 @@ exit 0
         # Gracefully stop the server so jobid's will continue from the last
         # jobid
         self.stop_and_restart_svr('normal')
-        self.submit_job(job_id='2004')
-        self.submit_job(lower=1, upper=2, job_id='2005[]')
-        self.submit_resv(resv_id='R2006')
+        self.submit_job(job_id='2003')
+        self.submit_job(lower=1, upper=2, job_id='2004[]')
+        self.submit_resv(resv_id='R2005')
 
         # Verify the sequence window, incase of submitting more than 1001 jobs
         # and all jobs should submit successfully without any duplication error


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
While restarting the server, the next JOBID is not consecutive.

#### Describe Your Change
Upon the graceful shutdown of the server, the next possible JOBID is being stored in DB instead of the last used ID. Thus when the server comes up, it generates the next seq from the DB stored value. This causes the server to skip one SEQ no in-between last used and next seq. 

Now, modified the code to save the currently used seq id. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Fix_jobid_seq.txt](https://github.com/subhasisb/pbspro/files/4490714/Fix_jobid_seq.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
