### PR TITLE
[WIP]Bug fixes for qterm crash, support FQDN and correcting pbs error no

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -168,7 +168,6 @@ extern "C" {
 #define PBSE_SSIGNON_UNSET_REJECT 15101	/* SVR_ssignon_enable not set */
 #define PBSE_SSIGNON_SET_REJECT 15102	/* SVR_ssignon_enable set */
 #define PBSE_SSIGNON_BAD_TRANSITION1 15103 /* bad attempt: true to false */
-#define PBSE_NOCONNECTION 15104		/* could not connect to any servers */
 
 /*
  * Error number 15104 for PBSE_SSIGNON_BAD_TRANSITION2
@@ -303,6 +302,7 @@ extern "C" {
 #define PBSE_NODE_BUSY	15227		 /* Node is busy */
 #define PBSE_DEFAULT_PARTITION 15228	/* Default partition name is not allowed */
 #define PBSE_HISTDEPEND  15229		/* Finished job did not satisfy dependency */
+#define PBSE_NOCONNECTION 15230		/* could not connect to any servers */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -484,6 +484,7 @@ enum mgr_obj {
 #define PBS_STDNG_RESV_ID_CHAR   'S'   /* Character in front of a resv ID */
 #define PBS_MNTNC_RESV_ID_CHAR   'M'   /* Character in front of a resv ID */
 #define PBS_AUTH_KEY_LEN    (129)
+#define PBS_MAXDAEMONNAME	(PBS_MAXHOSTNAME + 18) /* max daemon name contains hostname and its port */
 
 /* the pair to this list is in module_pbs_v1.c and must be updated to reflect any changes */
 enum batch_op {	SET, UNSET, INCR, DECR,

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -484,7 +484,7 @@ enum mgr_obj {
 #define PBS_STDNG_RESV_ID_CHAR   'S'   /* Character in front of a resv ID */
 #define PBS_MNTNC_RESV_ID_CHAR   'M'   /* Character in front of a resv ID */
 #define PBS_AUTH_KEY_LEN    (129)
-#define PBS_MAXDAEMONNAME	(PBS_MAXHOSTNAME + 18) /* max daemon name contains hostname and its port */
+#define PBS_MAXDAEMONNAME	(273)  /* max daemon name for multi servers */
 
 /* the pair to this list is in module_pbs_v1.c and must be updated to reflect any changes */
 enum batch_op {	SET, UNSET, INCR, DECR,

--- a/src/lib/Libifl/pbsD_termin.c
+++ b/src/lib/Libifl/pbsD_termin.c
@@ -86,6 +86,11 @@ send_terminate(int c, int sock, int manner, char *extend)
 
 	reply = PBSD_rdrpy_sock(sock, &rc);
 
+	if (reply == NULL) {
+		pbs_errno = PBSE_PROTOCOL;
+		return pbs_errno;
+	}
+
 	if (set_conn_errno(c, reply->brp_code) != 0) {
 		pbs_errno = reply->brp_code;
 		return pbs_errno;
@@ -95,7 +100,7 @@ send_terminate(int c, int sock, int manner, char *extend)
 	if (reply->brp_choice == BATCH_REPLY_CHOICE_Text) {
 		if (reply->brp_un.brp_txt.brp_str != NULL) {
 			if (set_conn_errtxt(c, reply->brp_un.brp_txt.brp_str) != 0) {
-				pbs_errno = PBSE_SYSTEM;
+				pbs_errno = PBSE_PROTOCOL;
 				return pbs_errno;
 			}
 		}

--- a/src/lib/Libifl/pbsD_termin.c
+++ b/src/lib/Libifl/pbsD_termin.c
@@ -87,7 +87,6 @@ send_terminate(int c, int sock, int manner, char *extend)
 	reply = PBSD_rdrpy_sock(sock, &rc);
 
 	if (reply == NULL) {
-		pbs_errno = PBSE_PROTOCOL;
 		return pbs_errno;
 	}
 
@@ -100,7 +99,7 @@ send_terminate(int c, int sock, int manner, char *extend)
 	if (reply->brp_choice == BATCH_REPLY_CHOICE_Text) {
 		if (reply->brp_un.brp_txt.brp_str != NULL) {
 			if (set_conn_errtxt(c, reply->brp_un.brp_txt.brp_str) != 0) {
-				pbs_errno = PBSE_PROTOCOL;
+				pbs_errno = PBSE_SYSTEM;
 				return pbs_errno;
 			}
 		}

--- a/src/lib/Libifl/pbsD_termin.c
+++ b/src/lib/Libifl/pbsD_termin.c
@@ -86,9 +86,9 @@ send_terminate(int c, int sock, int manner, char *extend)
 
 	reply = PBSD_rdrpy_sock(sock, &rc);
 
-	if (reply == NULL) {
+	if (reply == NULL)
 		return pbs_errno;
-	}
+
 
 	if (set_conn_errno(c, reply->brp_code) != 0) {
 		pbs_errno = reply->brp_code;

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -275,6 +275,7 @@ parse_psi(char * conf_value)
 	char *host;
 	int port;
 	int count = 0;
+	char fullhost[PBS_MAXHOSTNAME+1];
 	free(pbs_conf.psi);
 
 	if (!(tmp = strdup(conf_value))) {
@@ -312,14 +313,26 @@ parse_psi(char * conf_value)
 		}
 		host = token;
 		if (*host == '\0') {
-			host = pbs_conf.pbs_server_name;
+			if (pbs_conf.pbs_server_host_name)
+				host = pbs_conf.pbs_server_host_name;
+			else if (pbs_conf.pbs_server_name)
+				host = pbs_conf.pbs_server_name;
+			else {
+				fprintf(stderr, "Unable to get host name");
+				return -1;
+			}
+		}
+
+		if ((get_fullhostname(host, fullhost, (sizeof(fullhost) - 1)) == -1)) {
+			fprintf(stderr, "Unable to get full host name");
+			return -1;
 		}
 
 		if (!(pbs_conf.psi[count] = calloc(1, sizeof(pbs_server_instance_t)))) {
 			fprintf(stderr, "Ran out of memory parsing configuration %s\n", conf_value);
 			return -1;
 		}
-		if (!(pbs_conf.psi[count]->name = strdup(host))) {
+		if (!(pbs_conf.psi[count]->name = strdup(fullhost))) {
 			fprintf(stderr, "Ran out of memory parsing multi-server configuration \n");
 			return -1;			
 		}

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -8313,6 +8313,10 @@ main(int argc, char *argv[])
 #ifdef WIN32
 
 	if (g_ssHandle != 0) SetServiceStatus(g_ssHandle, &ss);
+
+	if (winsock_init()) {
+		return 1;
+	}
 	/* load the pbs conf file */
 	if (pbs_loadconf(0) == 0) {
 		g_dwCurrentState = SERVICE_STOPPED;
@@ -8843,9 +8847,6 @@ main(int argc, char *argv[])
 #endif  /* not DEBUG and not NO_SECURITY_CHECK */
 
 #ifdef	WIN32
-	if (winsock_init()) {
-		return 1;
-	}
 
 	/* Under WIN32, create structure that will be used to track child processes. */
 	if (initpids() == 0) {

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -782,6 +782,7 @@ main(int argc, char **argv)
 
 	pbs_net_t		pbs_scheduler_addr;
 	unsigned int		pbs_scheduler_port;
+	int number_cfg_servers = 1;
 
 	extern int		optind;
 	extern char		*optarg;
@@ -834,7 +835,8 @@ main(int argc, char **argv)
 	if (pbs_loadconf(0) == 0)
 		return (1);
 	/* initialize the shard lib */
-	if (pbs_shard_init(get_max_servers(), (server_instance_t **)pbs_conf.psi, get_current_servers()) == -1)
+	number_cfg_servers = get_current_servers(); 
+	if (pbs_shard_init(get_max_servers(), (server_instance_t **)pbs_conf.psi, number_cfg_servers) == -1)
 		return (1);
 
 	set_log_conf(pbs_conf.pbs_leaf_name, pbs_conf.pbs_mom_node_name,
@@ -1023,13 +1025,11 @@ main(int argc, char **argv)
 	}
 
 	if (get_max_servers() > 1) {
-		char buf[PBS_MAXHOSTNAME+18];
+		char buf[PBS_MAXDAEMONNAME];
 		if (!(self.name = strdup(server_host))) {
 			log_err(-1, __func__, "Out of memory\n");
 			return -1;			
 		}
-		if ((pc = strchr(self.name, (int)'.')) != NULL)
-			*pc = '\0';
 		self.port = pbs_server_port_dis;
 		if ((myindex = get_svr_index(&self)) == -1) {
 			fprintf(stderr, "pbsconf error: Wrong Multi Server configuration\n");


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Qterm is crashing, the actual issue is when the first server goes down, it kills the Postgres server too. Thus causing the subsequent server termination failure. 
* If suppose the system is configured with FQDN, the comparison with pbs.conf's server instance value would fail. 
* PBS errno was not right.

#### Describe Your Change
* Adding a condition for stopping DB server only single-server mode, allowing to run for multi-server mode, so that other servers could access the Postgres.
* Supporting FQDN.
* Updating correct PBS errno. 


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
