### PR TITLE
Bugfix for qterm crash and correcting errno

### DIFF
--- a/src/include/pbs_error.h
+++ b/src/include/pbs_error.h
@@ -168,7 +168,6 @@ extern "C" {
 #define PBSE_SSIGNON_UNSET_REJECT 15101	/* SVR_ssignon_enable not set */
 #define PBSE_SSIGNON_SET_REJECT 15102	/* SVR_ssignon_enable set */
 #define PBSE_SSIGNON_BAD_TRANSITION1 15103 /* bad attempt: true to false */
-#define PBSE_NOCONNECTION 15104		/* could not connect to any servers */
 
 /*
  * Error number 15104 for PBSE_SSIGNON_BAD_TRANSITION2
@@ -303,6 +302,7 @@ extern "C" {
 #define PBSE_NODE_BUSY	15227		 /* Node is busy */
 #define PBSE_DEFAULT_PARTITION 15228	/* Default partition name is not allowed */
 #define PBSE_HISTDEPEND  15229		/* Finished job did not satisfy dependency */
+#define PBSE_NOCONNECTION 15230		/* could not connect to any servers */
 
 /* the following structure is used to tie error number      */
 /* with text to be returned to a client, see svr_messages.c */

--- a/src/lib/Libifl/pbsD_termin.c
+++ b/src/lib/Libifl/pbsD_termin.c
@@ -86,6 +86,8 @@ send_terminate(int c, int sock, int manner, char *extend)
 
 	reply = PBSD_rdrpy_sock(sock, &rc);
 
+	if (reply == NULL)
+		return pbs_errno;
 	if (set_conn_errno(c, reply->brp_code) != 0) {
 		pbs_errno = reply->brp_code;
 		return pbs_errno;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1878,7 +1878,8 @@ try_db_again:
 		shutdown_nodes();
 
 	/* if brought up the DB, take it down */
-	stop_db();
+	if (get_max_servers() == 1)
+		stop_db();
 
 	if (are_primary == FAILOVER_SECONDARY) {
 		/* we are the secondary server */

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1878,8 +1878,7 @@ try_db_again:
 		shutdown_nodes();
 
 	/* if brought up the DB, take it down */
-	if (get_max_servers() == 1)
-		stop_db();
+	stop_db();
 
 	if (are_primary == FAILOVER_SECONDARY) {
 		/* we are the secondary server */
@@ -2400,6 +2399,9 @@ void
 stop_db()
 {
 	char *db_err = NULL;
+
+	if (get_max_servers() > 1)
+		return; /* No need to stop in Multi-server case */
 
 	pbs_db_disconnect(svr_db_conn);
 	pbs_db_destroy_connection(svr_db_conn);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
* Qterm is crashing, the actual issue is when the first server goes down, it kills the Postgres server too. Thus causing the subsequent server termination failure.
* PBS errno was not right.

#### Describe Your Change
* Adding a condition for stopping DB server only single-server mode, allowing to run for multi-server mode, so that other servers could access the Postgres.
* Updating correct PBS errno.

Testing logs with multiple servers:
[Quickfix_qterm_crash.txt](https://github.com/subhasisb/pbspro/files/4534405/Quickfix_qterm_crash.txt)
