### PR TITLE
Shard fix

### DIFF
--- a/src/cmds/scripts/pbs_db_schema.sql
+++ b/src/cmds/scripts/pbs_db_schema.sql
@@ -62,7 +62,6 @@ INSERT INTO pbs.info values('1.4.0'); /* schema version */
  * Table pbs.server holds server object information
  */
 CREATE TABLE pbs.server (
-    sv_jobidnumber  BIGINT      NOT NULL,
     sv_savetm       TIMESTAMP   NOT NULL,
     sv_creattm      TIMESTAMP   NOT NULL,
     attributes      hstore      NOT NULL DEFAULT ''	

--- a/src/include/pbs_db.h
+++ b/src/include/pbs_db.h
@@ -151,7 +151,6 @@ typedef struct pbs_db_attr_list pbs_db_attr_list_t;
 struct pbs_db_svr_info {
 	char  sv_creattm[DB_TIMESTAMP_LEN + 1];
 	char  sv_savetm[DB_TIMESTAMP_LEN + 1];
-	BIGINT  sv_jobidnumber;
 	pbs_db_attr_list_t cache_attr_list; /* list of attributes */
 	pbs_db_attr_list_t db_attr_list; /* list of attributes */
 };

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -186,7 +186,6 @@ struct server {
 		int		sv_numjobs;	/* number of job owned by server   */
 		int		sv_numque;	/* nuber of queues managed          */
 		long long sv_jobidnumber;	/* next number to use in new jobid  */
-		long long sv_lastid; /* block increment to avoid many saves */
 	} sv_qs;
 	attribute sv_attr[SRV_ATR_LAST]; /* the server attributes 	    */
 	char	  sv_savetm[DB_TIMESTAMP_LEN + 1];

--- a/src/include/svrfunc.h
+++ b/src/include/svrfunc.h
@@ -134,6 +134,8 @@ extern pbs_queue *find_resvqueuebyname(char *quename);
 extern resc_resv *find_resv_by_quename(char *quename);
 extern int make_schedselect(attribute *patrl, resource *pselect, pbs_queue *pque, attribute *psched);
 extern long long get_next_svr_sequence_id(void);
+extern long long load_svinst_last_jobid(int sv_index);
+extern int save_svinst_last_jobid(int sv_index, long long last_jobid);
 
 #ifdef _PROVISION_H
 extern int find_prov_vnode_list(job *, exec_vnode_listtype *, char **);

--- a/src/lib/Libdb/db_postgres_svr.c
+++ b/src/lib/Libdb/db_postgres_svr.c
@@ -65,24 +65,22 @@ int
 pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 {
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "insert into pbs.server( "
-		"sv_jobidnumber, "
 		"sv_savetm, "
 		"sv_creattm, "
 		"attributes "
 		") "
 		"values "
-		"($1, localtimestamp, localtimestamp, hstore($2::text[])) "
+		"(localtimestamp, localtimestamp, hstore($1::text[])) "
 		"returning to_char(sv_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as sv_savetm");
-	if (pg_prepare_stmt(conn, STMT_INSERT_SVR, conn->conn_sql, 2) != 0)
+	if (pg_prepare_stmt(conn, STMT_INSERT_SVR, conn->conn_sql, 1) != 0)
 		return -1;
 
 	/* replace all attributes for a FULL update */
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.server set "
-		"sv_jobidnumber = $1, "
 		"sv_savetm = localtimestamp, "
-		"attributes = attributes || hstore($2::text[]) "
+		"attributes = attributes || hstore($1::text[]) "
 		"returning to_char(sv_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as sv_savetm");
-	if (pg_prepare_stmt(conn, STMT_UPDATE_SVR, conn->conn_sql, 2) != 0)
+	if (pg_prepare_stmt(conn, STMT_UPDATE_SVR, conn->conn_sql, 1) != 0)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "update pbs.server set "
@@ -93,7 +91,6 @@ pg_db_prepare_svr_sqls(pbs_db_conn_t *conn)
 		return -1;
 
 	snprintf(conn->conn_sql, MAX_SQL_LENGTH, "select "
-		"sv_jobidnumber, "
 		"to_char(sv_savetm, 'YYYY-MM-DD HH24:MI:SS.US') as sv_savetm, "
 		"to_char(sv_creattm, 'YYYY-MM-DD HH24:MI:SS.US') as sv_creattm, "
 		"hstore_to_array(attributes) as attributes "
@@ -165,7 +162,6 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 	static int fnums_inited = 0;
 
 	/* Svr does not have a QS area, so ignoring that */
-	SET_PARAM_BIGINT(conn, ps->sv_jobidnumber, 0);
 
 	/* are there attributes to save to memory or local cache? */
 	if (ps->cache_attr_list.attr_count > 0) {
@@ -177,8 +173,8 @@ pg_db_save_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj, int savetype)
 		if ((len = attrlist_2_dbarray(&raw_array, &ps->db_attr_list)) <= 0)
 			return -1;
 
-		SET_PARAM_BIN(conn, raw_array, len, 1);
-		params = 2;
+		SET_PARAM_BIN(conn, raw_array, len, 0);
+		params = 1;
 		stmt = STMT_UPDATE_SVR;
 	}
 
@@ -223,21 +219,19 @@ pg_db_load_svr(pbs_db_conn_t *conn, pbs_db_obj_info_t *obj)
 	int rc;
 	char *raw_array;
 	pbs_db_svr_info_t *ps = obj->pbs_db_un.pbs_db_svr;
-	static int sv_jobidnumber_fnum, sv_savetm_fnum, sv_creattm_fnum, attributes_fnum;
+	static int sv_savetm_fnum, sv_creattm_fnum, attributes_fnum;
 	static int fnums_inited = 0;
 
 	if ((rc = pg_db_query(conn, STMT_SELECT_SVR, 0, &res)) != 0)
 		return rc;
 
 	if (fnums_inited == 0) {
-		sv_jobidnumber_fnum = PQfnumber(res, "sv_jobidnumber");
 		sv_savetm_fnum = PQfnumber(res, "sv_savetm");
 		sv_creattm_fnum = PQfnumber(res, "sv_creattm");
 		attributes_fnum = PQfnumber(res, "attributes");
 		fnums_inited = 1;
 	}
 
-	GET_PARAM_BIGINT(res, 0, ps->sv_jobidnumber, sv_jobidnumber_fnum);
 	GET_PARAM_STR(res, 0, ps->sv_savetm, sv_savetm_fnum);
 	GET_PARAM_STR(res, 0, ps->sv_creattm, sv_creattm_fnum);
 	GET_PARAM_BIN(res, 0, raw_array, attributes_fnum);

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -342,7 +342,7 @@ load_svinst_last_jobid(int sv_index)
 	FILE *fp;
 
 	sprintf(last_jobidfile, "%s/%s/server_%d.lastjobid", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE, sv_index);
-	if (!(fp = fopen(last_jobidfile, "rt"))) {
+	if (!(fp = fopen(last_jobidfile, "r"))) {
 		if (errno != ENOENT) { /* be silent if file does not exist */
 			sprintf(log_buffer, "unable to open lastjobid file %s", last_jobidfile);
 			log_err(errno, msg_daemonname, log_buffer);
@@ -377,7 +377,7 @@ save_svinst_last_jobid(int sv_index, long long last_jobid)
 	FILE *fp;
 
 	sprintf(last_jobidfile, "%s/%s/server_%d.lastjobid", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE, sv_index);
-	if (!(fp = fopen(last_jobidfile, "wt"))) {
+	if (!(fp = fopen(last_jobidfile, "w"))) {
 		sprintf(log_buffer, "unable to open lastjobid file %s", last_jobidfile);
 		log_err(errno, msg_daemonname, log_buffer);
 		return (-1);

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -191,6 +191,7 @@ extern pbs_list_head       prov_allvnodes;
 extern int 		max_concurrent_prov;
 extern int		brought_up_db;
 extern pbs_db_conn_t	*svr_db_conn;
+extern int myindex;
 
 extern	pbs_list_head	svr_allhooks;
 
@@ -321,6 +322,72 @@ init_server_attrs()
 
 	}
 }
+
+#ifndef PBS_MOM
+
+/**
+ * @brief
+ *		get the last saved jobid by this server instance
+ *
+ * @param[in]	sv_index - The index of this server
+ *
+ * @return	last jobid >= 0
+ *
+ */
+long long
+load_svinst_last_jobid(int sv_index)
+{
+	char last_jobidfile[MAXPATHLEN+1];
+	long long last_jobid;
+	FILE *fp;
+
+	sprintf(last_jobidfile, "%s/%s/server_%d.lastjobid", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE, sv_index);
+	if (!(fp = fopen(last_jobidfile, "rt"))) {
+		if (errno != ENOENT) { /* be silent if file does not exist */
+			sprintf(log_buffer, "unable to open lastjobid file %s", last_jobidfile);
+			log_err(errno, msg_daemonname, log_buffer);
+		}
+		return (0);
+	}
+	fscanf(fp, "%lld", &last_jobid);
+	fclose(fp);
+
+	if (last_jobid < 0)
+		last_jobid = 0;
+
+	return last_jobid;
+}
+
+/**
+ * @brief
+ *		save the last saved jobid by this server instance
+ *
+ * @param[in] sv_index    - The index of this server
+ * @param[in] last_jobid  - the jobid sequence to save
+ *
+ * @return error code
+ * @retval 0 - error
+ * @retval 1 - failure
+ *
+ */
+int
+save_svinst_last_jobid(int sv_index, long long last_jobid)
+{
+	char last_jobidfile[MAXPATHLEN+1];
+	FILE *fp;
+
+	sprintf(last_jobidfile, "%s/%s/server_%d.lastjobid", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE, sv_index);
+	if (!(fp = fopen(last_jobidfile, "wt"))) {
+		sprintf(log_buffer, "unable to open lastjobid file %s", last_jobidfile);
+		log_err(errno, msg_daemonname, log_buffer);
+		return (-1);
+	}
+	fprintf(fp, "%lld\n", last_jobid);
+	fclose(fp);
+
+	return 0;
+}
+#endif
 
 /**
  * @brief
@@ -524,6 +591,9 @@ pbsd_init(int type)
 		a_opt = server.sv_attr[(int)SRV_ATR_scheduling].at_val.at_long;
 
 	init_server_attrs();
+
+	/* retrieve the server job-id number from a file for this instance */
+	server.sv_qs.sv_jobidnumber = load_svinst_last_jobid(myindex);
 
 	/* 5. If not a "create" initialization, recover server db */
 	/*    and sched db					  */

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -209,7 +209,7 @@ unsigned int	pbs_rm_port;
 pbs_net_t	pbs_server_addr;
 unsigned int	pbs_server_port_dis;
 pbs_server_instance_t self;
-int myindex = 0;
+int myindex = 0; /* defaults to 0 for single server mode */
 /*
  * the names of the Server:
  *    pbs_server_name - from PBS_SERVER_HOST_NAME
@@ -1844,7 +1844,7 @@ try_db_again:
 	DBPRT(("Server out of main loop, state is %ld\n", *state))
 
 	/* set the current seq id to the last id before final save */
-	server.sv_qs.sv_lastid = server.sv_qs.sv_jobidnumber;
+	save_svinst_last_jobid(myindex, server.sv_qs.sv_jobidnumber);
 	svr_save_db(&server);	/* final recording of server */
 	track_save(NULL);	/* save tracking data	     */
 

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3331,21 +3331,21 @@ long long
 get_next_svr_sequence_id(void)
 {
 	static long long lastid = -1;
-	long long seq = server.sv_qs.sv_jobidnumber;
+	long long next = server.sv_qs.sv_jobidnumber; /* only for returning */
 
-	/* If server job limit is over, reset back to zero */
-	if (++server.sv_qs.sv_jobidnumber > svr_max_job_sequence_id) {
-		server.sv_qs.sv_jobidnumber = 0;
+	server.sv_qs.sv_jobidnumber = 
+		pbs_shard_get_next_seqid(server.sv_qs.sv_jobidnumber, svr_max_job_sequence_id, myindex);
+	
+	if (server.sv_qs.sv_jobidnumber == 0) {
 		lastid = -1;
 	}
 
-	/* check if we should save jobid */
+	/* check if we should save jobid increments now */
 	if (lastid == -1 ||  server.sv_qs.sv_jobidnumber == lastid) {
 		lastid = ((server.sv_qs.sv_jobidnumber / 1000)+1)*1000;
-		server.sv_qs.sv_lastid = lastid;
-		svr_save_db(&server);
+		save_svinst_last_jobid(myindex, lastid);
 	}
-	return seq;
+	return next;
 }
 
 

--- a/src/server/svr_recov_db.c
+++ b/src/server/svr_recov_db.c
@@ -131,7 +131,6 @@ svr_2_db(struct server *ps, pbs_db_svr_info_t *pdbsvr)
 	int savetype = 0;
 
 	strcpy(pdbsvr->sv_savetm, ps->sv_savetm);
-	pdbsvr->sv_jobidnumber = ps->sv_qs.sv_lastid;
 
 	if ((encode_attr_db(svr_attr_def, ps->sv_attr, (int)SRV_ATR_LAST, &pdbsvr->cache_attr_list, &pdbsvr->db_attr_list, 1)) != 0) /* encode all attributes */
 		return -1;
@@ -159,7 +158,6 @@ db_2_svr(struct server *ps, pbs_db_svr_info_t *pdbsvr)
 		return -1;
 
 	strcpy(ps->sv_savetm, pdbsvr->sv_savetm);
-	ps->sv_qs.sv_jobidnumber = pdbsvr->sv_jobidnumber;
 
 	return 0;
 }

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -45,57 +45,8 @@ class TestTrillionJobid(TestFunctional):
 
     update_svr_db_script = """#!/bin/bash
 . %s
-. ${PBS_EXEC}/libexec/pbs_pgsql_env.sh
 
-DATA_PORT=${PBS_DATA_SERVICE_PORT}
-if [ -z ${DATA_PORT} ]; then
-    DATA_PORT=15007
-fi
-
-sudo ls ${PBS_HOME}/server_priv/db_user &>/dev/null
-if [ $? -eq 0 ]; then
-    DATA_USER=`sudo cat ${PBS_HOME}/server_priv/db_user`
-    if [ $? -ne 0 ]; then
-        exit 1
-    fi
-fi
-
-sudo ${PBS_EXEC}/sbin/pbs_ds_password test
-if [ $? -eq 0 ]; then
-    sudo ${PBS_EXEC}/sbin/pbs_dataservice stop
-    if [ $? -ne 0 ]; then
-        exit 1
-    fi
-fi
-
-sudo ${PBS_EXEC}/sbin/pbs_dataservice status
-if [ $? -eq 0 ]; then
-    sudo ${PBS_EXEC}/sbin/pbs_dataservice stop
-    if [ $? -ne 0 ]; then
-        exit 1
-    fi
-fi
-
-sudo ${PBS_EXEC}/sbin/pbs_dataservice start
-if [ $? -ne 0 ]; then
-    exit 1
-fi
-
-args="-U ${DATA_USER} -p ${DATA_PORT} -d pbs_datastore"
-PGPASSWORD=test ${PGSQL_BIN}/psql ${args} <<-EOF
-    UPDATE pbs.server SET sv_jobidnumber = %d;
-EOF
-
-ret=$?
-if [ $ret -eq 0 ]; then
-    echo "Server sv_jobidnumber attribute has been updated successfully"
-fi
-
-sudo ${PBS_EXEC}/sbin/pbs_dataservice stop
-if [ $? -ne 0 ]; then
-    exit 1
-fi
-
+echo %d > $PBS_HOME/server_priv/server_0.lastjobid
 exit 0
 
 """

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -66,7 +66,7 @@ exit 0
             (conf_path, num))
         self.du.chmod(path=fn, mode=0o755)
         fail_msg = 'Failed to set sequence id in database'
-        ret = self.du.run_cmd(cmd=fn)
+        ret = self.du.run_cmd(cmd=fn, sudo=True)
         self.assertEqual(ret['rc'], 0, fail_msg)
         # Start the PBS server
         start_msg = 'Failed to restart PBS'


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
With multiple server instances, we cannot store the last used jobid in a single value in the database, since each server has it's own advancement. We cannot also simply deduce this from the available jobs in the database at startup, since jobs may finish and in that case we will repeat jobids, which is not desirable at customer sites and will break analytical tools.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
So, the change proposed in this is to save the last used jobid from each server instance in its own file in pbs_home/server_priv/sever_<instance-id>.lastjobid. Also modified the trillion jobid test case to update last jobid accordingly. This would obviously work for single or multiple server instances. 

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
![image](https://user-images.githubusercontent.com/15310678/80705074-61c9cf80-8b03-11ea-853c-800d224613ef.png)
