### PR TITLE
Multiserver support in pbs_init.d

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -364,7 +364,7 @@ case "$1" in
 			${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
 			if [ $? -eq 0 ]; then
 				if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
-					echo "PBS Servers is running. Cannot stop PBS Data Service now."
+					echo "PBS Servers are running. Cannot stop PBS Data Service now."
 				else
 					echo "PBS server is running. Cannot stop PBS Data Service now."
 					server_pid="`ps -ef | grep "${PBS_EXEC}/sbin/pbs_server.bi[n]" | awk '{print $2}'`"

--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -367,7 +367,7 @@ case "$1" in
 					echo "PBS Servers are running. Cannot stop PBS Data Service now."
 				else
 					echo "PBS server is running. Cannot stop PBS Data Service now."
-					server_pid="`ps -ef | grep "${PBS_EXEC}/sbin/pbs_server.bi[n]" | awk '{print $2}'`"
+					server_pid="`ps -ef | grep "pbs_server.bi[n]" | awk '{print $2}'`"
 					if [ -z "${server_pid}" ]; then
 						server_host="`${PBS_EXEC}/bin/qstat -Bf | grep 'server_host' | awk '{print $NF}'`"
 						if [ ! -z "${server_host}" ]; then

--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -57,7 +57,7 @@ get_db_user() {
 
 # The get_port function does the following:
 # Setting PBS_DATA_SERVICE_PORT based on availability  in following order:
-# 1. Set PBS_DATA_SERVICE_PORT to port provided by pbs 
+# 1. Set PBS_DATA_SERVICE_PORT to port provided by pbs
 # 2. Set PBS_DATA_SERVICE_PORT to port provided by pbs.conf
 # 3. Set PBS_DATA_SERVICE_PORT to port provided by /etc/services
 # 4. Set PBS_DATA_SERVICE_PORT to default port
@@ -66,7 +66,7 @@ get_port() {
 
 	if [ "$1" ]; then
 		PBS_DATA_SERVICE_PORT="$1"
-		
+
 	else
 		if [ -z "${PBS_DATA_SERVICE_PORT}" ]; then
 		    PBS_DATA_SERVICE_PORT=`awk '{if($1=="pbs_dataservice") {x=$2}} END {{split(x,a,"/")} {if ( a[2] == "tcp" ) print a[1]}}' /etc/services`
@@ -163,10 +163,10 @@ fi
 
 #
 # The check_status function does the following:
-# Checks what pg_ctl thinks about the database status. If pg_ctl says db is up, 
+# Checks what pg_ctl thinks about the database status. If pg_ctl says db is up,
 # just return 0 (running locally) else check if the datastore directory can be
 # locked.
-# If we cannot obtain exclusive lock, then return 2 
+# If we cannot obtain exclusive lock, then return 2
 #
 # Return code values:
 #	-1 - failed to execute
@@ -191,9 +191,9 @@ check_status() {
 
   if [ ${status} -eq 0 ]; then
 	echo "$res" | grep 'no server running'
-	if [ $? -eq 0 ]; then 
-		status=1 
-	else 
+	if [ $? -eq 0 ]; then
+		status=1
+	else
 		msg="PBS data service running locally"
 	fi
   else
@@ -226,11 +226,11 @@ oom_protect() {
 
 
 #
-# Launch monitoring by invoking the pbs_dataservice_monitor program 
-# with the "monitor" parameter. If the monitor returns a 0 exit status, it 
+# Launch monitoring by invoking the pbs_dataservice_monitor program
+# with the "monitor" parameter. If the monitor returns a 0 exit status, it
 # means it has been able to aquire a lock on a flag file, and so we can continue
 # to start the data service by calling pg_ctl.
-# This function also protects the database and the monitoring script from the 
+# This function also protects the database and the monitoring script from the
 # OOM on linux.
 # This function checks whether systemd (i.e. systemctl) is available on system or not?
 # If systemctl is available then register database processes with pbs.service
@@ -314,13 +314,13 @@ start_dataservice() {
 
 data_srv_mon="${PBS_EXEC}/sbin/pbs_ds_monitor"
 
-# 
+#
 # If second parameter is specified as "PBS" it means this was called from the PBS daemons
 # In such a case we do not want to be very verbose (as we only need the error code and msg)
 # When stop is called from command line we do a regular postgres stop, but when called from PBS
 # we do a "fast" stop of postgres. The "fast" stop disconnects any existing clients to ensure that
 # the postgres daemons are indeed stopped when PBS is stopped
-# 
+#
 
 case "$1" in
 	start|startasync)
@@ -361,16 +361,20 @@ case "$1" in
 		fi
 		if [ "$2" != "PBS" ]; then
 			# Check if PBS is running
-			${PBS_EXEC}/bin/qstat >/dev/null 2>&1
+			${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
 			if [ $? -eq 0 ]; then
-				echo "PBS server is running. Cannot stop PBS Data Service now."
-				server_pid="`ps -ef | grep "${PBS_EXEC}/sbin/pbs_server.bi[n]" | awk '{print $2}'`"
-				if [ -z "${server_pid}" ]; then
-					server_host="`${PBS_EXEC}/bin/qstat -Bf | grep 'server_host' | awk '{print $NF}'`"
-					if [ ! -z "${server_host}" ]; then
-						echo "PBS server is running on host ${server_host}."
+				if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
+					echo "PBS Servers is running. Cannot stop PBS Data Service now."
+				else
+					echo "PBS server is running. Cannot stop PBS Data Service now."
+					server_pid="`ps -ef | grep "${PBS_EXEC}/sbin/pbs_server.bi[n]" | awk '{print $2}'`"
+					if [ -z "${server_pid}" ]; then
+						server_host="`${PBS_EXEC}/bin/qstat -Bf | grep 'server_host' | awk '{print $NF}'`"
+						if [ ! -z "${server_host}" ]; then
+							echo "PBS server is running on host ${server_host}."
+						fi
+						echo "Please check pbs.conf file to verify PBS is configured with correct server host value. Exiting."
 					fi
-					echo "Please check pbs.conf file to verify PBS is configured with correct server host value. Exiting."
 				fi
 				exit 1
 			fi
@@ -423,7 +427,7 @@ case "$1" in
 		fi
 		exit ${ret}
 		;;
-	
+
 	status)
 		check_status
 		ret=$?

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -536,10 +536,10 @@ fi
 # in the given list of server instances for this
 # script
 if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
-	_first_svr=${PBS_SERVER_INSTANCES%%,*}
-	_first_svr=${_first_svr#*:}
-	export PBS_BATCH_SERVICE_PORT=${_first_svr}
-	unset _first_svr
+	_first_svr_port=${PBS_SERVER_INSTANCES%%,*}
+	_first_svr_port=${_first_svr_port#*:}
+	export PBS_BATCH_SERVICE_PORT=${_first_svr_port}
+	unset _first_svr_port
 fi
 
 # Get the current PBS Pro version from qstat

--- a/src/cmds/scripts/pbs_habitat.in
+++ b/src/cmds/scripts/pbs_habitat.in
@@ -241,7 +241,7 @@ upgrade_pbs_database() {
 		echo "Database version file: ${data_dir}/PG_VERSION not found, cannot continue"
 		return 1
 	fi
-	
+
 	sys_pgsql_ver=$(echo `${PGSQL_BIN}/postgres -V` | awk 'NR==1 {print $NF}' | cut -d '.' -f 1,2)
 	old_pgsql_ver=`cat ${data_dir}/PG_VERSION`
 	# strip the minor version from sys_pgsql_ver if old_pgsql_ver does not have minor version (for comparison).
@@ -532,6 +532,16 @@ if [ -f "$PBS_HOME/pbs_version" ]; then
 	old_pbs_version=`cat $PBS_HOME/pbs_version`
 fi
 
+# If multiserver is configure then use first server
+# in the given list of server instances for this
+# script
+if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
+	_first_svr=${PBS_SERVER_INSTANCES%%,*}
+	_first_svr=${_first_svr#*:}
+	export PBS_BATCH_SERVICE_PORT=${_first_svr}
+	unset _first_svr
+fi
+
 # Get the current PBS Pro version from qstat
 if [ -x "$PBS_EXEC/bin/qstat" ]; then
 	pbs_version=`"${PBS_EXEC}/bin/qstat" --version | sed -e 's/^.* = //'`
@@ -666,7 +676,7 @@ if [ "${PBS_START_SERVER:-0}" != 0 ] ; then
 				echo "The PBS Pro database must be manually upgraded. Please refer to the"
 				echo "instructions in the release notes for version @PBS_VERSION@ located here:"
 				echo "https://github.com/PBSPro/pbspro/releases"
-			else 
+			else
 				echo "Failed to upgrade PBS Datastore"
 			fi
 			exit $ret

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -302,7 +302,7 @@ start_server() {
 }
 
 start_local_servers() {
-	local _started_any=0 _svr _host _port
+	local _svr _host _port
 
 	if [ "x${PBS_SERVER_INSTANCES}" == "x" ]; then
 		if ! check_server
@@ -313,10 +313,6 @@ start_local_servers() {
 			if ! start_server
 			then
 				return 1
-			fi
-			if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
-				echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
-				${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_startup"
 			fi
 		else
 			echo "PBS Server already running."
@@ -337,19 +333,11 @@ start_local_servers() {
 				if ! start_server ${_port}
 				then
 					return 1
-				else
-					_started_any=1
 				fi
 			else
 				echo "PBS Server (on port ${_port}) already running."
 			fi
 		done
-		if [ ${_started_any} -eq 1 ]; then
-			if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
-				echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
-				${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_startup"
-			fi
-		fi
 	fi
 }
 
@@ -533,10 +521,6 @@ stop_local_servers() {
 				else
 					echo "This is active server, shutting down with qterm, secondary will take over."
 				fi
-				if [ -r "${PBS_HOME}/server_priv/qmgr_shutdown" ]; then
-					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
-					${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_shutdown"
-				fi
 				${PBS_EXEC}/bin/qterm -t quick
 				echo "PBS server - was pid: ${_pid}"
 			elif [ ${is_secondary} -eq 1 ]; then
@@ -549,10 +533,6 @@ stop_local_servers() {
 				kill ${_pid}
 				echo "PBS server - was pid: ${_pid}"
 			fi
-		fi
-		${PBS_EXEC}/sbin/pbs_dataservice status > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
 		fi
 	else
 		for _svr in ${PBS_SERVER_INSTANCES//,/ }
@@ -582,66 +562,13 @@ stop_local_servers() {
 				_pid=${_svr#*:}
 				echo "PBS server (on port ${_port}) - was pid: ${_pid}"
 			done
-			${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
-			if [ $? -ne 0 ]; then
-				# All servers are down, shutdown db if running
-				${PBS_EXEC}/sbin/pbs_dataservice status > /dev/null 2>&1
-				if [ $? -eq 0 ]; then
-					${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
-				fi
-			fi
 		fi
 	fi
+	${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
 }
 
-stop_pbs() {
-    echo "Stopping PBS"
-    update_pids
-    if [ "${PBS_START_SERVER}" -gt 0 ]; then
-      stop_local_servers
-    fi
-    if [ "${PBS_START_MOM}" -gt 0 ]; then
-      if check_prog "mom" ; then
-	site_mom_cleanup
-	kill ${pbs_mom_pid}
-	echo "PBS mom - was pid: ${pbs_mom_pid}"
-      fi
-    fi
-    if [ "${PBS_START_SCHED}" -gt 0 ]; then
-      if check_prog "sched" ; then
-	if [ ${is_secondary} -eq 0 ]; then
-	  kill ${pbs_sched_pid}
-	  echo "PBS sched - was pid: ${pbs_sched_pid}"
-	else
-	  kill ${pbs_secondary_sched_pid}
-	  echo "PBS schedx - was pid: ${pbs_secondary_sched_pid}"
-	  rm -f ${PBS_HOME}/sched_priv/sched.lock.secondary
-	fi
-      fi
-    fi
-    if [ "${PBS_START_COMM}" -gt 0 ]; then
-      if check_prog "pbs_comm" ; then
-	if [ ${is_secondary} -eq 0 ]; then
-	  kill -TERM ${pbs_comm_pid}
-	  echo "PBS comm - was pid: ${pbs_comm_pid}"
-	else
-	  kill -TERM ${pbs_secondary_comm_pid}
-	  echo "PBS comm - was pid: ${pbs_secondary_comm_pid}"
-	  rm -f ${PBS_HOME}/server_priv/comm.lock.secondary
-	fi
-      fi
-    fi
-    if [ -f ${redhat_subsys_filepath} ]; then
-	  rm -f ${redhat_subsys_filepath}
-    fi
-    # make sure the daemons have exited for up to 180 seconds
-    # if any still there, exit with message and error
-    waitloop=1
-    echo "Waiting for shutdown to complete"
-    while [ ${waitloop} -lt 180 ]
-    do
-	sleep 1
-	something_running=""
+wait_local_servers() {
+	local _running=""
 	if [ "${PBS_START_SERVER}" -gt 0 ]; then
 		if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
 			for _svr in ${PBS_SERVER_INSTANCES//,/ }
@@ -650,38 +577,93 @@ stop_pbs() {
 				_port=${_svr#*:}
 				if check_server ${_port}
 				then
-					something_running="${something_running} pbs_server (on port ${_port})"
+					_running="${_running} pbs_server (on port ${_port})"
 				fi
 			done
 		else
 			if check_server
 			then
-				something_running=" pbs_server"
+				_running=" pbs_server"
 			fi
 		fi
 	fi
+	echo ${_running}
+}
+
+# make sure the daemons have exited for up to 180 seconds
+# if any still there, exit with message and error
+wait_pbs() {
+	local waitloop=1 something_running
+	echo "Waiting for shutdown to complete"
+	while [ ${waitloop} -lt 180 ]
+	do
+		sleep 1
+		something_running="$(wait_local_servers)"
+		if [ "${PBS_START_MOM}" -gt 0 ]; then
+			if check_prog "mom" ; then
+				something_running="${something_running} pbs_mom"
+			fi
+		fi
+		if [ "${PBS_START_SCHED}" -gt 0 ]; then
+			if check_prog "sched" ; then
+				something_running="${something_running} pbs_sched"
+			fi
+		fi
+		if [ "${PBS_START_COMM}" -gt 0 ]; then
+			if check_prog "pbs_comm" ; then
+				something_running=" pbs_comm"
+			fi
+		fi
+		if [ "${something_running}" = "" ]; then
+			return
+		fi
+		waitloop=`expr ${waitloop} + 1`
+	done
+	echo "Unable to stop PBS,${something_running} still active"
+	exit 1
+}
+
+stop_pbs() {
+	echo "Stopping PBS"
+	update_pids
+	if [ "${PBS_START_SERVER}" -gt 0 ]; then
+		stop_local_servers
+	fi
 	if [ "${PBS_START_MOM}" -gt 0 ]; then
-	    if check_prog "mom" ; then
-		something_running="${something_running} pbs_mom"
-	    fi
+		if check_prog "mom" ; then
+			site_mom_cleanup
+			kill ${pbs_mom_pid}
+			echo "PBS mom - was pid: ${pbs_mom_pid}"
+		fi
 	fi
 	if [ "${PBS_START_SCHED}" -gt 0 ]; then
-	    if check_prog "sched" ; then
-		something_running="${something_running} pbs_sched"
-	    fi
+		if check_prog "sched" ; then
+			if [ ${is_secondary} -eq 0 ]; then
+				kill ${pbs_sched_pid}
+				echo "PBS sched - was pid: ${pbs_sched_pid}"
+			else
+				kill ${pbs_secondary_sched_pid}
+				echo "PBS schedx - was pid: ${pbs_secondary_sched_pid}"
+				rm -f ${PBS_HOME}/sched_priv/sched.lock.secondary
+			fi
+		fi
 	fi
 	if [ "${PBS_START_COMM}" -gt 0 ]; then
-	    if check_prog "pbs_comm" ; then
-		something_running=" pbs_comm"
-	    fi
+		if check_prog "pbs_comm" ; then
+			if [ ${is_secondary} -eq 0 ]; then
+				kill -TERM ${pbs_comm_pid}
+				echo "PBS comm - was pid: ${pbs_comm_pid}"
+			else
+				kill -TERM ${pbs_secondary_comm_pid}
+				echo "PBS comm - was pid: ${pbs_secondary_comm_pid}"
+				rm -f ${PBS_HOME}/server_priv/comm.lock.secondary
+			fi
+		fi
 	fi
-	if [ "${something_running}" = "" ]; then
-	    return
+	if [ -f ${redhat_subsys_filepath} ]; then
+		rm -f ${redhat_subsys_filepath}
 	fi
-	waitloop=`expr ${waitloop} + 1`
-    done
-    echo "Unable to stop PBS,${something_running} still active"
-    exit 1
+	wait_pbs
 }
 
 status_server() {

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -112,7 +112,7 @@ check_started() {
 		return 1
 	fi
   ps_out=`ps -p $1 -o args 2> /dev/null | tail -1`
-  if [ -z "${ps_out}" -o "`echo ${ps_out} | cut -c1`" = "[" ]  ; then
+  if [ -z "${ps_out}" -o "`echo ${ps_out} | cut -c1`" = "[" ]; then
     ps_out=`ps -p $1 -o command 2> /dev/null | tail -1`
     if [ -z "${ps_out}" ]; then
 	return 1
@@ -121,7 +121,7 @@ check_started() {
 
 # strip out everything except executable name
   prog_name=`echo ${ps_out} | grep -how "$2"`
-  if [ "x${prog_name}" = "x$2" ] ; then
+  if [ "x${prog_name}" = "x$2" ]; then
     return 0;
   fi
 
@@ -146,14 +146,14 @@ check_prog() {
         pid=${pbs_mom_pid} ;;
     sched)
         daemon_name="pbs_sched"
-        if [ ${is_secondary} -eq 0 ] ; then
+        if [ ${is_secondary} -eq 0 ]; then
             pid=${pbs_sched_pid} ;
         else
             pid=${pbs_secondary_sched_pid} ;
         fi ;;
     pbs_comm)
         daemon_name="pbs_comm"
-        if [ ${is_secondary} -eq 0 ] ; then
+        if [ ${is_secondary} -eq 0 ]; then
             pid=${pbs_comm_pid} ;
         else
             pid=${pbs_secondary_comm_pid} ;
@@ -224,7 +224,7 @@ check_core() {
 # Return the name of the PBS server host
 get_server_hostname() {
 	shn=""
-	if [ -z "${PBS_PRIMARY}" -o -z "${PBS_SECONDARY}" ] ; then
+	if [ -z "${PBS_PRIMARY}" -o -z "${PBS_SECONDARY}" ]; then
 		if [ -z "${PBS_SERVER_HOST_NAME}" ]; then
 			shn="${PBS_SERVER}"
 		else
@@ -246,7 +246,7 @@ check_hostname() {
 }
 
 get_server_pid() {
-	local _lockfn="" _pid=""
+	local _lockfn=""
 	if [ "x$1" != "x" ]; then
 		_lockfn="server_${1}.lock"
 	else
@@ -282,7 +282,7 @@ start_server() {
 	if [ ${ret_val} -eq 0 ]; then
 		echo "PBS server${_portmsg}"
 		return 0
-	elif [ ${ret_val} -eq 4 ] ; then
+	elif [ ${ret_val} -eq 4 ]; then
 		echo "pbs_server${_portmsg} failed to start, will retry once in 30 seconds" >&2
 		sleep 30
 		if [ "x$1" != "x" ]; then
@@ -307,7 +307,7 @@ start_local_servers() {
 	if [ "x${PBS_SERVER_INSTANCES}" == "x" ]; then
 		if ! check_server
 		then
-			if [ -f ${pbslibdir}/init.d/limits.pbs_server ] ; then
+			if [ -f ${pbslibdir}/init.d/limits.pbs_server ]; then
 				. ${pbslibdir}/init.d/limits.pbs_server
 			fi
 			if ! start_server
@@ -322,7 +322,7 @@ start_local_servers() {
 			echo "PBS Server already running."
 		fi
 	else
-		if [ -f ${pbslibdir}/init.d/limits.pbs_server ] ; then
+		if [ -f ${pbslibdir}/init.d/limits.pbs_server ]; then
 			. ${pbslibdir}/init.d/limits.pbs_server
 		fi
 		for _svr in ${PBS_SERVER_INSTANCES//,/ }
@@ -358,7 +358,7 @@ start_pbs() {
 
     # Perform sanity checks
     server_hostname=`get_server_hostname`
-    if [ -z "${server_hostname}" -o "${server_hostname}" = 'CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME' ] ; then
+    if [ -z "${server_hostname}" -o "${server_hostname}" = 'CHANGE_THIS_TO_PBS_PRO_SERVER_HOSTNAME' ]; then
 	echo "***" >&2
 	echo "*** The hostname of the PBS Pro server in ${conf} is invalid." >&2
 	echo "*** Update the configuration file before starting PBS Pro." >&2
@@ -436,7 +436,7 @@ start_pbs() {
         echo "Warning: Please inform your administrator immediately or contact Altair customer support"
     fi
 
-    if [ "${PBS_START_COMM}" -gt 0 ] ; then
+    if [ "${PBS_START_COMM}" -gt 0 ]; then
       if check_prog "pbs_comm" ; then
 	echo "PBS comm already running."
       else
@@ -451,16 +451,16 @@ start_pbs() {
       fi
     fi
 
-    if [ "${PBS_START_MOM}" -gt 0 ] ; then
+    if [ "${PBS_START_MOM}" -gt 0 ]; then
       if check_prog "mom" ; then
 	echo "PBS mom already running."
       else
-        if [ -f ${pbslibdir}/init.d/limits.pbs_mom ] ; then
+        if [ -f ${pbslibdir}/init.d/limits.pbs_mom ]; then
             . ${pbslibdir}/init.d/limits.pbs_mom
         fi
 	check_maxsys
 	site_mom_startup
-        if [ "XX${BGLDIR}" != "XX" ] && [ "XX${DB2DIR}" != "XX" ] ; then
+        if [ "XX${BGLDIR}" != "XX" ] && [ "XX${DB2DIR}" != "XX" ]; then
 	    env LD_LIBRARY_PATH=$DB2DIR/lib64:$DB2DIR/lib ${PBS_EXEC}/sbin/pbs_mom
 	    echo "PBS Blue Gene mom"
         else
@@ -487,11 +487,11 @@ start_pbs() {
       fi
     fi
 
-    if [ "${PBS_START_SCHED}" -gt 0 ] ; then
+    if [ "${PBS_START_SCHED}" -gt 0 ]; then
       if check_prog "sched" ; then
 	echo "PBS scheduler already running."
       else
-         if [ -f ${pbslibdir}/init.d/limits.pbs_sched ] ; then
+         if [ -f ${pbslibdir}/init.d/limits.pbs_sched ]; then
              . ${pbslibdir}/init.d/limits.pbs_sched
          fi
 	 if ${PBS_EXEC}/sbin/pbs_sched
@@ -505,14 +505,14 @@ start_pbs() {
       fi
     fi
 
-    if [ "${PBS_START_SERVER}" -gt 0 ] ; then
+    if [ "${PBS_START_SERVER}" -gt 0 ]; then
       start_local_servers
     fi
 
-    if [ -f ${pbslibdir}/init.d/limits.post_services ] ; then
+    if [ -f ${pbslibdir}/init.d/limits.post_services ]; then
         . ${pbslibdir}/init.d/limits.post_services
     fi
-    if [ -f /etc/redhat-release ] ; then
+    if [ -f /etc/redhat-release ]; then
 	touch ${redhat_subsys_filepath}
     fi
 
@@ -597,19 +597,19 @@ stop_local_servers() {
 stop_pbs() {
     echo "Stopping PBS"
     update_pids
-    if [ "${PBS_START_SERVER}" -gt 0 ] ; then
+    if [ "${PBS_START_SERVER}" -gt 0 ]; then
       stop_local_servers
     fi
-    if [ "${PBS_START_MOM}" -gt 0 ] ; then
+    if [ "${PBS_START_MOM}" -gt 0 ]; then
       if check_prog "mom" ; then
 	site_mom_cleanup
 	kill ${pbs_mom_pid}
 	echo "PBS mom - was pid: ${pbs_mom_pid}"
       fi
     fi
-    if [ "${PBS_START_SCHED}" -gt 0 ] ; then
+    if [ "${PBS_START_SCHED}" -gt 0 ]; then
       if check_prog "sched" ; then
-	if [ ${is_secondary} -eq 0 ] ; then
+	if [ ${is_secondary} -eq 0 ]; then
 	  kill ${pbs_sched_pid}
 	  echo "PBS sched - was pid: ${pbs_sched_pid}"
 	else
@@ -619,9 +619,9 @@ stop_pbs() {
 	fi
       fi
     fi
-    if [ "${PBS_START_COMM}" -gt 0 ] ; then
+    if [ "${PBS_START_COMM}" -gt 0 ]; then
       if check_prog "pbs_comm" ; then
-	if [ ${is_secondary} -eq 0 ] ; then
+	if [ ${is_secondary} -eq 0 ]; then
 	  kill -TERM ${pbs_comm_pid}
 	  echo "PBS comm - was pid: ${pbs_comm_pid}"
 	else
@@ -631,7 +631,7 @@ stop_pbs() {
 	fi
       fi
     fi
-    if [ -f ${redhat_subsys_filepath} ] ; then
+    if [ -f ${redhat_subsys_filepath} ]; then
 	  rm -f ${redhat_subsys_filepath}
     fi
     # make sure the daemons have exited for up to 180 seconds
@@ -642,7 +642,7 @@ stop_pbs() {
     do
 	sleep 1
 	something_running=""
-	if [ "${PBS_START_SERVER}" -gt 0 ] ; then
+	if [ "${PBS_START_SERVER}" -gt 0 ]; then
 		if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
 			for _svr in ${PBS_SERVER_INSTANCES//,/ }
 			do
@@ -660,17 +660,17 @@ stop_pbs() {
 			fi
 		fi
 	fi
-	if [ "${PBS_START_MOM}" -gt 0 ] ; then
+	if [ "${PBS_START_MOM}" -gt 0 ]; then
 	    if check_prog "mom" ; then
 		something_running="${something_running} pbs_mom"
 	    fi
 	fi
-	if [ "${PBS_START_SCHED}" -gt 0 ] ; then
+	if [ "${PBS_START_SCHED}" -gt 0 ]; then
 	    if check_prog "sched" ; then
 		something_running="${something_running} pbs_sched"
 	    fi
 	fi
-	if [ "${PBS_START_COMM}" -gt 0 ] ; then
+	if [ "${PBS_START_COMM}" -gt 0 ]; then
 	    if check_prog "pbs_comm" ; then
 		something_running=" pbs_comm"
 	    fi
@@ -713,24 +713,24 @@ status_local_servers() {
 
 status_pbs() {
     update_pids
-    if [ "${PBS_START_SERVER}" -gt 0 ] ; then
+    if [ "${PBS_START_SERVER}" -gt 0 ]; then
       status_local_servers
     fi
-    if [ "${PBS_START_MOM}" -gt 0 ] ; then
+    if [ "${PBS_START_MOM}" -gt 0 ]; then
       if check_prog "mom" ; then
 	echo "pbs_mom is pid ${pbs_mom_pid}"
       else
 	echo "pbs_mom is not running"
       fi
     fi
-    if [ "${PBS_START_SCHED}" -gt 0 ] ; then
+    if [ "${PBS_START_SCHED}" -gt 0 ]; then
       if check_prog "sched" ; then
 	echo "pbs_sched is pid ${pbs_sched_pid}"
       else
 	echo "pbs_sched is not running"
       fi
     fi
-    if [ "${PBS_START_COMM}" -gt 0 ] ; then
+    if [ "${PBS_START_COMM}" -gt 0 ]; then
       if check_prog "pbs_comm" ; then
 	echo "pbs_comm is ${pbs_comm_pid}"
       else
@@ -781,7 +781,7 @@ find_bgl_environment ()
 {
 
 	bgldef=""
-        if [ "XX${BRIDGE_CONFIG_FILE}" != "XX" ] ; then
+        if [ "XX${BRIDGE_CONFIG_FILE}" != "XX" ]; then
         	bgldef0=`dirname $BRIDGE_CONFIG_FILE 2>/dev/null`
         	bgldef=`dirname $bgldef0 2>/dev/null`
 	fi
@@ -790,7 +790,7 @@ find_bgl_environment ()
 
         BGLDIR=""
         for path in $bglpaths ; do
-                if [ -d  "$path" ] ; then
+                if [ -d  "$path" ]; then
                         BGLDIR="$path"
                         break
                 fi
@@ -799,7 +799,7 @@ find_bgl_environment ()
         db2paths="$DB2DIR /opt/IBM/db2/V8.1"
         DB2DIR=""
         for path in $db2paths ; do
-                if [ -d  "$path" ] ; then
+                if [ -d  "$path" ]; then
                         DB2DIR="$path"
                         break
                 fi
@@ -928,9 +928,9 @@ is_boottime()
 	[ $? -ne 0 ] && return 1
 
 	PYTHON_EXE=${PBS_EXEC}/python/bin/python
-	if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ] ; then
+	if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ]; then
 		PYTHON_EXE=`type python3 2>/dev/null | cut -d' ' -f3`
-		if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ] ; then
+		if [ -z "${PYTHON_EXE}" -o ! -x "${PYTHON_EXE}" ]; then
 			return 1
 		fi
 	fi
@@ -938,7 +938,7 @@ is_boottime()
 	BOOTPYFILE="${pbslibdir}/python/pbs_bootcheck.py"
 	BOOTCHECKFILE="/var/tmp/pbs_boot_check"
 
-	if [ ! -r "${BOOTPYFILE}" ] ; then
+	if [ ! -r "${BOOTPYFILE}" ]; then
 		return 1
 	fi
 
@@ -983,11 +983,11 @@ conf=${PBS_CONF_FILE:-/etc/pbs.conf}
 
 rm -f "${env_save}"
 
-if [ -z "${PBS_EXEC}" ] ; then
+if [ -z "${PBS_EXEC}" ]; then
     echo "PBS_EXEC is undefined." >&2
     exit 1
 fi
-if [ ! -d "${PBS_EXEC}" ] ; then
+if [ ! -d "${PBS_EXEC}" ]; then
     echo "${PBS_EXEC} is not a directory." >&2
     echo "PBS_EXEC directory does not exist: ${PBS_EXEC}" >&2
     exit 1
@@ -996,7 +996,7 @@ fi
 pbslibdir="${PBS_EXEC}/lib"
 [  ! -d "${pbslibdir}" -a -d "${PBS_EXEC}/lib64" ] && pbslibdir="${PBS_EXEC}/lib64"
 
-if [ -z "${PBS_HOME}" ] ; then
+if [ -z "${PBS_HOME}" ]; then
     echo "PBS_HOME is undefined." >&2
     exit 1
 fi

--- a/src/cmds/scripts/pbs_init.d.in
+++ b/src/cmds/scripts/pbs_init.d.in
@@ -81,8 +81,6 @@ getpid() {
 # update_pids may cause an I/O read to block if PBS_HOME is on a shared
 # mount, it is called selectively after sanity checks are performed
 update_pids() {
-	pbs_server_pid=`getpid ${PBS_HOME}/server_priv/server.lock`
-	pbs_secondary_server_pid=`getpid ${PBS_HOME}/server_priv/server.lock.secondary`
 	pbs_mom_pid=`getpid ${PBS_MOM_HOME}/mom_priv/mom.lock`
 	pbs_sched_pid=`getpid ${PBS_HOME}/sched_priv/sched.lock`
 	pbs_secondary_sched_pid=`getpid ${PBS_HOME}/sched_priv/sched.lock.secondary`
@@ -110,7 +108,9 @@ lc_host_name()
 #
 : check_started
 check_started() {
-
+	if [ "x${1}" == "x" -o "x${1}" == "x-1" ]; then
+		return 1
+	fi
   ps_out=`ps -p $1 -o args 2> /dev/null | tail -1`
   if [ -z "${ps_out}" -o "`echo ${ps_out} | cut -c1`" = "[" ]  ; then
     ps_out=`ps -p $1 -o command 2> /dev/null | tail -1`
@@ -132,9 +132,7 @@ check_started() {
 #              get the pid out of the prog.lock file and run check_started
 #	       on that pid.
 #
-#	$1 is either "server" "oldserver" "mom" or "sched"
-#		"oldserver" is for non-database server (pbs_server)
-#		as opposed to "pbs_server.bin"
+#	$1 is either "mom" or "sched" or "pbs_comm"
 #
 # return value: 0 - program is still running
 #		1 - program is not running
@@ -146,20 +144,6 @@ check_prog() {
     mom)
         daemon_name="pbs_mom"
         pid=${pbs_mom_pid} ;;
-    server)
-        daemon_name="pbs_server.bin"
-        if [ ${is_secondary} -eq 0 ] ; then
-            pid=${pbs_server_pid}
-        else
-            pid=${pbs_secondary_server_pid}
-        fi ;;
-    oldserver)
-        daemon_name="pbs_server"
-        if [ ${is_secondary} -eq 0 ] ; then
-            pid=${pbs_server_pid}
-        else
-            pid=${pbs_secondary_server_pid}
-        fi ;;
     sched)
         daemon_name="pbs_sched"
         if [ ${is_secondary} -eq 0 ] ; then
@@ -179,13 +163,9 @@ check_prog() {
 	 return 1;;
   esac
 
-  if [ -n "${pid}" ]; then
-    if [ "${pid}" -ne -1 ] ; then
       if check_started "${pid}" "$daemon_name" ; then
         return 0
       fi
-    fi
-  fi
 
   # Since the pid file does not exist, PBS has never been run
   return 1
@@ -263,6 +243,114 @@ check_hostname() {
 	# Check DNS
 	host "${1}" >/dev/null 2>&1 && return 0
 	return 1
+}
+
+get_server_pid() {
+	local _lockfn="" _pid=""
+	if [ "x$1" != "x" ]; then
+		_lockfn="server_${1}.lock"
+	else
+		_lockfn="server.lock"
+	fi
+	if [ ${is_secondary} -eq 1 -a "x${PBS_SERVER_INSTANCES}" == "x" ]; then
+		_lockfn="${_lockfn}.secondary"
+	fi
+	echo "`getpid ${PBS_HOME}/server_priv/${_lockfn}`"
+}
+
+check_server() {
+	local _pid="`get_server_pid $1`"
+	if check_started "${_pid}" "pbs_server.bin"
+	then
+		return 0
+	fi
+	return 1
+}
+
+start_server() {
+	local _portmsg=""
+	if [ "x$1" != "x" ]; then
+		_portmsg=" (on port $1)"
+	fi
+	if [ "x$1" != "x" ]; then
+		PBS_BATCH_SERVICE_PORT=$1 ${PBS_EXEC}/sbin/pbs_server
+		ret_val=$?
+	else
+		${PBS_EXEC}/sbin/pbs_server
+		ret_val=$?
+	fi
+	if [ ${ret_val} -eq 0 ]; then
+		echo "PBS server${_portmsg}"
+		return 0
+	elif [ ${ret_val} -eq 4 ] ; then
+		echo "pbs_server${_portmsg} failed to start, will retry once in 30 seconds" >&2
+		sleep 30
+		if [ "x$1" != "x" ]; then
+			PBS_BATCH_SERVICE_PORT=$1 ${PBS_EXEC}/sbin/pbs_server
+			ret_val=$?
+		else
+			${PBS_EXEC}/sbin/pbs_server
+			ret_val=$?
+		fi
+		if [ ${ret_val} -eq 0 ]; then
+			echo "PBS server${_portmsg}"
+			return 0
+		fi
+	fi
+	echo "pbs_server${_portmsg} startup failed, exit ${ret_val} aborting." >&2
+	return 1
+}
+
+start_local_servers() {
+	local _started_any=0 _svr _host _port
+
+	if [ "x${PBS_SERVER_INSTANCES}" == "x" ]; then
+		if ! check_server
+		then
+			if [ -f ${pbslibdir}/init.d/limits.pbs_server ] ; then
+				. ${pbslibdir}/init.d/limits.pbs_server
+			fi
+			if ! start_server
+			then
+				return 1
+			fi
+			if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
+				echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
+				${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_startup"
+			fi
+		else
+			echo "PBS Server already running."
+		fi
+	else
+		if [ -f ${pbslibdir}/init.d/limits.pbs_server ] ; then
+			. ${pbslibdir}/init.d/limits.pbs_server
+		fi
+		for _svr in ${PBS_SERVER_INSTANCES//,/ }
+		do
+			_host=${_svr%%:*}
+			_port=${_svr#*:}
+			# FIXME: For now we are assuming everything is in single host
+			# Once we have multi-host multi-server we have to check host
+			# to be equal to local host
+			if ! check_server ${_port}
+			then
+				if ! start_server ${_port}
+				then
+					return 1
+				else
+					_started_any=1
+				fi
+			else
+				echo "PBS Server (on port ${_port}) already running."
+			fi
+		done
+		if [ ${_started_any} -eq 1 ]; then
+			if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
+				echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
+				${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_startup"
+			fi
+		fi
+	fi
 }
 
 start_pbs() {
@@ -418,37 +506,7 @@ start_pbs() {
     fi
 
     if [ "${PBS_START_SERVER}" -gt 0 ] ; then
-      if check_prog "server" || check_prog "oldserver" ; then
-	echo "PBS Server already running."
-      else
-         if [ -f ${pbslibdir}/init.d/limits.pbs_server ] ; then
-             . ${pbslibdir}/init.d/limits.pbs_server
-         fi
-	 if ${PBS_EXEC}/sbin/pbs_server ; then
-            echo "PBS server"
-         else
-            ret_val=$?
-	    if [ $ret_val -eq 4 ] ; then
-		echo "pbs_server failed to start, will retry once in 30 seconds" >&2
-		sleep 30
-	        if ${PBS_EXEC}/sbin/pbs_server ; then
-		    echo "PBS server"
-		else
-		    ret_val=$?
-            	    echo "pbs_server startup failed, exit ${ret_val} aborting." >&2
-		    return 1
-		fi
-	    else
-		echo "pbs_server startup failed, exit ${ret_val} aborting." >&2
-		return 1
-	    fi
-	 fi
-
-         if [ -r "${PBS_HOME}/server_priv/qmgr_startup" ]; then
-           echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_startup"
-           ${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_startup"
-         fi
-      fi
+      start_local_servers
     fi
 
     if [ -f ${pbslibdir}/init.d/limits.post_services ] ; then
@@ -461,41 +519,86 @@ start_pbs() {
     return 0
 }
 
+stop_local_servers() {
+	local _act_svr _pid _svr _host _port _pids
+
+	if [ "x${PBS_SERVER_INSTANCES}" == "x" ]; then
+		_act_svr=`lc_host_name \`${PBS_EXEC}/bin/qstat -Bf 2>/dev/null | grep "server_host = " | sed -e "s/.*server_host = //"\``
+		if check_server
+		then
+			_pid=`get_server_pid`
+			if [ "${my_hostname}" = "${_act_svr}" ]; then
+				if [ -z "${PBS_SECONDARY}" -o ${is_secondary} -eq 1 ]; then
+					echo "Shutting server down with qterm."
+				else
+					echo "This is active server, shutting down with qterm, secondary will take over."
+				fi
+				if [ -r "${PBS_HOME}/server_priv/qmgr_shutdown" ]; then
+					echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
+					${PBS_EXEC}/bin/qmgr < "${PBS_HOME}/server_priv/qmgr_shutdown"
+				fi
+				${PBS_EXEC}/bin/qterm -t quick
+				echo "PBS server - was pid: ${_pid}"
+			elif [ ${is_secondary} -eq 1 ]; then
+				echo "This is secondary server, killing process."
+				kill ${_pid}
+				echo "PBS server - was pid: ${_pid}"
+				rm -f ${PBS_HOME}/server_priv/server.lock.secondary
+			else
+				echo "Killing Server."
+				kill ${_pid}
+				echo "PBS server - was pid: ${_pid}"
+			fi
+		fi
+		${PBS_EXEC}/sbin/pbs_dataservice status > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
+		fi
+	else
+		for _svr in ${PBS_SERVER_INSTANCES//,/ }
+		do
+			_host=${_svr%%:*}
+			_port=${_svr#*:}
+			_pid=`get_server_pid ${_port}`
+			if [ "x${_pid}" != "x-1" ]; then
+				_pids="${_pids} ${_port}:${_pid}"
+			fi
+		done
+		if [ "x${_pids}" != "x" ]; then
+			${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				echo "Shutting servers down with qterm."
+				${PBS_EXEC}/bin/qterm -t quick
+			else
+				echo "Killing Servers."
+				for _svr in ${_pids}
+				do
+					kill ${_svr#*:}
+				done
+			fi
+			for _svr in ${_pids}
+			do
+				_port=${_svr%%:*}
+				_pid=${_svr#*:}
+				echo "PBS server (on port ${_port}) - was pid: ${_pid}"
+			done
+			${PBS_EXEC}/bin/qstat -Bf >/dev/null 2>&1
+			if [ $? -ne 0 ]; then
+				# All servers are down, shutdown db if running
+				${PBS_EXEC}/sbin/pbs_dataservice status > /dev/null 2>&1
+				if [ $? -eq 0 ]; then
+					${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
+				fi
+			fi
+		fi
+	fi
+}
+
 stop_pbs() {
     echo "Stopping PBS"
     update_pids
     if [ "${PBS_START_SERVER}" -gt 0 ] ; then
-      active_server=`lc_host_name \`${PBS_EXEC}/bin/qstat -Bf 2>/dev/null | \
-	  grep "server_host = " | \
-	  sed -e "s/.*server_host = //"\``
-      if check_prog "server" || check_prog "oldserver"; then
-	if [ "${my_hostname}" = "${active_server}" ]; then
-	  if [ -z "${PBS_SECONDARY}" -o ${is_secondary} -eq 1 ]; then
-	    echo "Shutting server down with qterm."
-	  else
-	    echo "This is active server, shutting down with qterm, secondary will take over."
-	  fi
-	  if [ -r "${PBS_HOME}/server_priv/qmgr_shutdown" ]; then
-	    echo "pbs_server evaluating ${PBS_HOME}/server_priv/qmgr_shutdown"
-	    ${PBS_EXEC}/bin/qmgr <"${PBS_HOME}/server_priv/qmgr_shutdown"
-	  fi
-	  ${PBS_EXEC}/bin/qterm -t quick
-	  echo "PBS server - was pid: ${pbs_server_pid}"
-	elif [ ${is_secondary} -eq 1 ]; then
-	  echo "This is secondary server, killing process."
-	  kill ${pbs_secondary_server_pid}
-	  echo "PBS server - was pid: ${pbs_secondary_server_pid}"
-	  rm -f ${PBS_HOME}/server_priv/server.lock.secondary
-	else
-	  echo "Killing Server."
-	  kill ${pbs_server_pid}
-	  echo "PBS server - was pid: ${pbs_server_pid}"
-	fi
-      fi
-      ${PBS_EXEC}/sbin/pbs_dataservice status > /dev/null 2>&1
-      if [ $? -eq 0 ]; then
-          ${PBS_EXEC}/sbin/pbs_dataservice stop > /dev/null 2>&1
-      fi
+      stop_local_servers
     fi
     if [ "${PBS_START_MOM}" -gt 0 ] ; then
       if check_prog "mom" ; then
@@ -540,9 +643,22 @@ stop_pbs() {
 	sleep 1
 	something_running=""
 	if [ "${PBS_START_SERVER}" -gt 0 ] ; then
-	    if check_prog "server" || check_prog "oldserver" ; then
-		something_running=" pbs_server"
-	    fi
+		if [ "x${PBS_SERVER_INSTANCES}" != "x" ]; then
+			for _svr in ${PBS_SERVER_INSTANCES//,/ }
+			do
+				_host=${_svr%%:*}
+				_port=${_svr#*:}
+				if check_server ${_port}
+				then
+					something_running="${something_running} pbs_server (on port ${_port})"
+				fi
+			done
+		else
+			if check_server
+			then
+				something_running=" pbs_server"
+			fi
+		fi
 	fi
 	if [ "${PBS_START_MOM}" -gt 0 ] ; then
 	    if check_prog "mom" ; then
@@ -568,14 +684,37 @@ stop_pbs() {
     exit 1
 }
 
+status_server() {
+	local _portmsg="" _port=$1
+	if [ "x$1" != "x" ]; then
+		_portmsg=" (on port ${_port})"
+	fi
+	if check_server ${_port}
+	then
+		echo "pbs_server${_portmsg} is pid `get_server_pid ${_port}`"
+	else
+		echo "pbs_server${_portmsg} is not running"
+	fi
+}
+
+status_local_servers() {
+	local _svr _host _port
+	if [ "x${PBS_SERVER_INSTANCES}" == "x" ]; then
+		status_server
+	else
+		for _svr in ${PBS_SERVER_INSTANCES//,/ }
+		do
+			_host=${_svr%%:*}
+			_port=${_svr#*:}
+			status_server ${_port}
+		done
+	fi
+}
+
 status_pbs() {
     update_pids
     if [ "${PBS_START_SERVER}" -gt 0 ] ; then
-      if check_prog "server" || check_prog "oldserver" ; then
-	echo "pbs_server is pid ${pid}"
-      else
-	echo "pbs_server is not running"
-      fi
+      status_local_servers
     fi
     if [ "${PBS_START_MOM}" -gt 0 ] ; then
       if check_prog "mom" ; then

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -872,7 +872,7 @@ main(int argc, char **argv)
 
 	if (!(self.name = strdup(server_host))) {
 		log_err(-1, __func__, "Out of memory\n");
-		return -1;			
+		return -1;
 	}
 	self.port = pbs_conf.batch_service_port;
 	if (get_max_servers() > 1) {
@@ -1043,10 +1043,10 @@ main(int argc, char **argv)
 		return (1);
 	}
 
-	/* make sure no other server is running with this home directory */
-
-	(void)sprintf(lockfile, "%s/%s/server.lock", pbs_conf.pbs_home_path,
-		PBS_SVR_PRIVATE);
+	if (get_max_servers() > 1)
+		(void)sprintf(lockfile, "%s/%s/server_%d.lock", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE, pbs_server_port_dis);
+	else
+		(void)sprintf(lockfile, "%s/%s/server.lock", pbs_conf.pbs_home_path, PBS_SVR_PRIVATE);
 	if ((are_primary = are_we_primary()) == FAILOVER_SECONDARY) {
 		strcat(lockfile, ".secondary");
 	} else if (are_primary == FAILOVER_CONFIG_ERROR) {


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Currently, the PBS init script doesn't support the start/stop/status of multiple servers.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changed init script and its dependent scripts to start/stop/status of multiple servers
(Assumption, all servers configured in PBS_SERVER_INSTANCES are assumed for local host, as we don't have support for multi-host multi-server support yet, once we have that, we have to change these scripts again)

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
None


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[after.txt](https://github.com/subhasisb/pbspro/files/4563567/after.txt)
![Screen Shot 2020-05-01 at 6 09 06 PM](https://user-images.githubusercontent.com/17191391/80805930-edf8f700-8bd6-11ea-928b-248b91ee7bd8.png)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
